### PR TITLE
Removes 'edit on GitHub' link from footer

### DIFF
--- a/src/site/_includes/footer.html
+++ b/src/site/_includes/footer.html
@@ -22,7 +22,6 @@
         <p>Company number 07742506, VAT&nbsp;registration number&nbsp;219&nbsp;5624&nbsp;96</p>
         <ul>
             <li><a href="/privacy-policy">Privacy policy</a>,</li>
-            <li><a href="https://github.com/tempertemper/tempertemper-website/tree/master/{{ page.inputPath }}">Edit this page on GitHub</a>,</li>
             <li><a href="/terms">Terms&nbsp;of&nbsp;business</a></li>
         </ul>
     </div>


### PR DESCRIPTION
This will be added back in at on point, when I'm able to make the repo public (basically, once I've removed the Perch config file from the repo).