### PR TITLE
Brings colour contrast to AAA

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -24,6 +24,9 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixes
 - Removes outline from heading link focus to fix multi-line overlap issues
 - Adds more redirects for categories to stop some 404s
+- Makes `<small>` text a different style rather than smaller
+- Amends colours in both light and dark mode, including highlight panels, to meet AAA colour contrast
+- Stops silly link underline removal in reset, then subsequent re-addition in the link stylesheet
 
 ----------
 

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -78,7 +78,10 @@
 
 @mixin highlight-box {
   background-color: $colour-primary-light;
-  @include dark-mode($background: $colour-dark-mode-highlight, $color: $colour-dark-mode-white);
+  @include dark-mode(
+    $background: $colour-dark-mode-highlight,
+    $color: $colour-dark-mode-white
+  );
   border-radius: $border-radius-default;
   padding: 1em;
 
@@ -86,16 +89,17 @@
     color: $colour-primary-darker;
     @include dark-mode($color: $colour-dark-mode-primary-lighter);
 
-    &:hover {
+    &:hover,
+    &:active,
+    &:focus {
       color: $colour-primary-lighter;
       @include dark-mode($color: $colour-dark-mode-primary);
     }
 
     &:active,
     &:focus {
-      color: $colour-primary;
       background-color: $white;
-      @include dark-mode($background: $colour-dark-mode-main, $color: $colour-dark-mode-primary);
+      @include dark-mode($background: $colour-dark-mode-main);
     }
   }
 }

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -78,15 +78,24 @@
 
 @mixin highlight-box {
   background-color: $colour-primary-light;
+  @include dark-mode($background: $colour-dark-mode-highlight, $color: $colour-dark-mode-white);
   border-radius: $border-radius-default;
   padding: 1em;
-  @include dark-mode($background: $colour-dark-mode-highlight, $color: $colour-dark-mode-white);
 
   a {
+    color: $colour-primary-darker;
+    @include dark-mode($color: $colour-dark-mode-primary-lighter);
 
+    &:hover {
+      color: $colour-primary-lighter;
+      @include dark-mode($color: $colour-dark-mode-primary);
+    }
+
+    &:active,
     &:focus {
+      color: $colour-primary;
       background-color: $white;
-      @include dark-mode($background: $colour-dark-mode-main);
+      @include dark-mode($background: $colour-dark-mode-main, $color: $colour-dark-mode-primary);
     }
   }
 }

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -11,7 +11,7 @@ $white: #fff;
 
 // Primary colours
 // $colour-primary: #0097db;
-$colour-primary: #007CB8;
+$colour-primary: #007CBA;
 $colour-primary-lighter: #008DD1;
 $colour-primary-light: #E6F7FF;
 $colour-primary-darker: #0073AB;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -10,11 +10,13 @@ $black: #0B0C0C;
 $white: #fff;
 
 // Primary colours
-$colour-primary: #0097db;
+// $colour-primary: #0097db;
+$colour-primary: #007CB8;
 $colour-primary-light: lighten($colour-primary, 53%);
 $colour-primary-darker: darken($colour-primary, 5%);
 
 // Dark mode colours
+$colour-dark-mode-primary: #009FE6;
 $colour-dark-mode-main: #2C2C2C;
 $colour-dark-mode-highlight: #3D3D3D;
 $colour-dark-mode-white: #f2f2f2;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -12,11 +12,14 @@ $white: #fff;
 // Primary colours
 // $colour-primary: #0097db;
 $colour-primary: #007CB8;
-$colour-primary-light: lighten($colour-primary, 53%);
-$colour-primary-darker: darken($colour-primary, 5%);
+$colour-primary-lighter: #008DD1;
+$colour-primary-light: #E6F7FF;
+$colour-primary-darker: #0073AB;
 
 // Dark mode colours
 $colour-dark-mode-primary: #009FE6;
+$colour-dark-mode-primary-lighter: #1AB3FF;
+$colour-dark-mode-primary-darker: #0095D9;
 $colour-dark-mode-main: #2C2C2C;
 $colour-dark-mode-highlight: #3D3D3D;
 $colour-dark-mode-white: #f2f2f2;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -17,9 +17,9 @@ $colour-primary-light: #E6F7FF;
 $colour-primary-darker: #0073AB;
 
 // Dark mode colours
-$colour-dark-mode-primary: #009FE6;
-$colour-dark-mode-primary-lighter: #1AB3FF;
-$colour-dark-mode-primary-darker: #0095D9;
+$colour-dark-mode-primary: #00A0F0;
+$colour-dark-mode-primary-lighter: #19B3FF;
+$colour-dark-mode-primary-darker: #008BD6;
 $colour-dark-mode-main: #2C2C2C;
 $colour-dark-mode-highlight: #3D3D3D;
 $colour-dark-mode-white: #f2f2f2;

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -8,11 +8,6 @@ html {
   box-sizing: inherit;
 }
 
-:link,
-:visited {
-  text-decoration: none;
-}
-
 body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -97,5 +97,6 @@ hr {
 
 small {
   display: block;
-  font-size: ms(-1);
+  font-size: ms(0);
+  font-style: italic;
 }

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -4,16 +4,14 @@
   &:visited {
     color: $colour-primary;
     text-decoration: underline;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-primary;
-    }
+    @include dark-mode($color: $colour-dark-mode-primary);
   }
 
   &:hover,
   &:active,
   &:focus {
-    color: $colour-primary-darker;
+    color: $colour-primary-lighter;
+    @include dark-mode($color: $colour-dark-mode-primary-darker);
   }
 }
 

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -10,13 +10,9 @@
   &:hover,
   &:active,
   &:focus {
-    color: $colour-primary-lighter;
+    color: $colour-primary-darker;
     @include dark-mode($color: $colour-dark-mode-primary-darker);
   }
-}
-
-a {
-  @include text-link;
 
   &:focus {
     box-shadow: 0 0 0 2px $colour-primary-light;
@@ -27,6 +23,10 @@ a {
       box-shadow: 0 0 0 2px $colour-dark-mode-highlight;
     }
   }
+}
+
+a {
+  @include text-link;
 
   h1 &,
   h2 &,

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -4,6 +4,10 @@
   &:visited {
     color: $colour-primary;
     text-decoration: underline;
+
+    @include dark-mode() {
+      color: $colour-dark-mode-primary;
+    }
   }
 
   &:hover,

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -3,7 +3,6 @@
   &:link,
   &:visited {
     color: $colour-primary;
-    text-decoration: underline;
     @include dark-mode($color: $colour-dark-mode-primary);
   }
 


### PR DESCRIPTION
- Makes `<small>` text a different style rather than smaller
- Amends colours in both light and dark mode, including highlight panels, to meet AAA colour contrast
- Stops silly link underline removal in reset, then subsequent re-addition in the link stylesheet
