### PR TITLE
Button accessibility fixes

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Removes
 - Removes unnecessary `<div>` surrounding intro paragraph
 - Removes 'back to resources' link after resource posts
+- Removes button focus styling when active to stop messiness on Firefox
 
 ### Fixes
 - Default paragraph margin fix

--- a/.changelog
+++ b/.changelog
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file. The format 
 - Adds `aria-label` attributes to all `<section>` elements
 - Adds [microdata](https://schema.org/BlogPosting) to blog posts and resources
 - New section spacing variable to make distances between elements more uniform
+- Makes links with a role of button actionable with `space` as well as `return`
+- Stops links that look like buttons being draggable with the `draggable="false"` attribute
 
 ### Changes
 - Updates version-bump-prompt and markdown-it-anchor packages

--- a/src/js/link-buttons.js
+++ b/src/js/link-buttons.js
@@ -1,4 +1,4 @@
-// Adapted from @jonhurrel's code on this GitHub Issue: https://github.com/alphagov/govuk_elements/pull/272
+// Adapted from @jonhurrel's code on this PR's comment thread: https://github.com/alphagov/govuk_elements/pull/272
 (function () {
   'use strict';
   function a11yClick(link) {

--- a/src/js/link-buttons.js
+++ b/src/js/link-buttons.js
@@ -1,0 +1,26 @@
+// Adapted from @jonhurrel's code on this GitHub Issue: https://github.com/alphagov/govuk_elements/pull/272
+(function () {
+  'use strict';
+  function a11yClick(link) {
+    // If the spacebar is pressed on a focussed button, don't scroll the page down
+    link.addEventListener('keydown', function(event) {
+      var code = event.charCode || event.keyCode;
+      if (code === 32) {
+        event.preventDefault();
+      }
+    });
+    // When the spacebar is released on a focussed button, click the button
+    link.addEventListener('keyup', function(event) {
+      var code = event.charCode || event.keyCode;
+      if (code === 32) {
+        event.preventDefault();
+        link.click();
+      }
+    });
+  }
+  // Apply this to every link with a role of "button" on the page
+  var a11yLink = document.querySelectorAll('a[role="button"]');
+  for ( var i = 0; i < a11yLink.length; i++ ) {
+    a11yClick( a11yLink[i] );
+  }
+})();

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -72,4 +72,8 @@
       background-color: $colour-dark-mode-primary-lighter;
     }
   }
+
+  &:focus:active {
+    box-shadow: none;
+  }
 }

--- a/src/site/_includes/call-to-action.html
+++ b/src/site/_includes/call-to-action.html
@@ -3,7 +3,7 @@
         {% if tags.includes('post') %}
             <h2 id="ctaLabel">Follow along</h2>
             <p>If you enjoyed this post and want to know when the next one is published, head to Twitter and hit ‘Follow’.</p>
-            <a class="button" href="{{ site.author.twitter | twitterLink }}">
+            <a class="button" draggable="false" role="button" href="{{ site.author.twitter | twitterLink }}">
                 {% include "svg/twitter.svg" %}
                 <span>{{ site.author.twitter }}</span>
             </a>
@@ -24,12 +24,12 @@
             <p><small>Your email won’t be passed to any third parties or used in any way that won’t be of benefit to you. Also, you can <a href="/mailing-list/unsubscribe">unsubscribe</a> at any time.</small></p>
         {% elif tags.includes('testimonial') %}
             <h2 id="ctaLabel">Want to work with me?</h2>
-            <a class="button" href="/contact">Say hello</a>
+            <a class="button" draggable="false" role="button" href="/contact">Say hello</a>
         {% endif %}
     {% else %}
         <h2 id="ctaLabel">Follow me</h2>
         <p>Keep up with my latest articles, accessibility and usability tips, and general ramblings over on Twitter.</p>
-        <a class="button" href="{{ site.author.twitter | twitterLink }}">
+        <a class="button" draggable="false" role="button" href="{{ site.author.twitter | twitterLink }}">
             {% include "svg/twitter.svg" %}
             <span>{{ site.author.twitter }}</span>
         </a>

--- a/src/site/_layouts/base.html
+++ b/src/site/_layouts/base.html
@@ -15,5 +15,6 @@
                 {% include "footer.html" %}
             </div>
         </div>
+        <script src="/assets/js/production.js"></script>
     </body>
 </html>


### PR DESCRIPTION
- Makes links with a role of button actionable with `space` as well as `return`
- Stops links that look like buttons being draggable with the `draggable="false"` attribute
- Removes button focus styling when active to stop messiness on Firefox