### PR TITLE
h1 size reduction, homepage h1 tweak and 'front-end' to 'frontend'

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changes
 - Adds some spacing top and bottom to pre code blocks
+- Reduces main heading (`<h1>`) size slightly
+- Uses 'development' rather than 'dev' in homepage `<h1>`
 
 ----------
 

--- a/.changelog
+++ b/.changelog
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
 - Adds some spacing top and bottom to pre code blocks
 - Reduces main heading (`<h1>`) size slightly
 - Uses 'development' rather than 'dev' in homepage `<h1>`
+- Removes hyphen from references to frontend development
 
 ----------
 

--- a/src/scss/base/typography/_mixins.scss
+++ b/src/scss/base/typography/_mixins.scss
@@ -68,7 +68,7 @@ $font--heading: 'FS Me Web', sans-serif;
   }
 
   @media (min-width: $l) {
-    font-size: ms(6);
+    font-size: ms(5);
   }
 }
 
@@ -81,7 +81,7 @@ $font--heading: 'FS Me Web', sans-serif;
   }
 
   @media (min-width: $m) {
-    font-size: ms(3);
+    font-size: ms(2);
     font-weight: 200;
   }
 

--- a/src/scss/components/_call-to-action.scss
+++ b/src/scss/components/_call-to-action.scss
@@ -6,10 +6,6 @@
 
   h2 {
     @include heading-xl;
-
-    @media (min-width: $l) {
-      font-size: ms(5);
-    }
   }
 
   form {

--- a/src/site/_layouts/home.html
+++ b/src/site/_layouts/home.html
@@ -37,7 +37,7 @@ layout: base.html
     <ul>
         <li><a href="/category/accessibility">Accessiblity</a> is about designing and building web interfaces that can be used by anyone, something I feel very strongly about.</li>
         <li><a href="/category/design">Designing</a> smart, usable interfaces, journeys and interactions is what I do best, and I enjoy analysing others’ great design.</li>
-        <li><a href="/category/development">Front-end development</a> is a huge passion of mine; HTML and CSS in particular, but anything from Git to Gulp.</li>
+        <li><a href="/category/development">Frontend development</a> is a huge passion of mine; HTML and CSS in particular, but anything from Git to Gulp.</li>
     </ul>
      <p>Or have a look at the <a href="/categories">full list of subjects</a> I write about.</p>
 </section>

--- a/src/site/about.md
+++ b/src/site/about.md
@@ -34,7 +34,7 @@ In 2016 I made the move from websites into digital products. I worked full-time 
 
 ### Gov.uk
 
-I've been working in government since early 2018 on a [Scrum](https://www.mountaingoatsoftware.com/agile/scrum) team in the Digital Delivery Centre. I'm the team's interaction designer, building my designs as working prototypes (in HTML/CSS/JavaScript) for usability testing, and also getting very involved in our service's front-end code and accessibility testing.
+I've been working in government since early 2018 on a [Scrum](https://www.mountaingoatsoftware.com/agile/scrum) team in the Digital Delivery Centre. I'm the team's interaction designer, building my designs as working prototypes (in HTML/CSS/JavaScript) for usability testing, and also getting very involved in our service's frontend code and accessibility testing.
 
 
 ## Sharing
@@ -43,7 +43,7 @@ I'm a big believer in sharing. The web community is exceptionally generous and I
 
 ### A local meetup
 
-In 2015 I co-founded Frontend NE, a [monthly front-end web development meetup](https://frontendne.co.uk) and [annual conference](https://2019.frontendne.co.uk). The meetup gives front-end web developers a place to learn more about their craft, as well as put the web-world to rights over beer and pizza; while the conference draws folk in from further afield for a day of talks, learning and fun.
+In 2015 I co-founded Frontend NE, a [monthly frontend web development meetup](https://frontendne.co.uk) and [annual conference](https://2019.frontendne.co.uk). The meetup gives frontend web developers a place to learn more about their craft, as well as put the web-world to rights over beer and pizza; while the conference draws folk in from further afield for a day of talks, learning and fun.
 
 ### Speaking
 

--- a/src/site/blog.html
+++ b/src/site/blog.html
@@ -2,8 +2,8 @@
 title: Articles by Martin Underhill
 heading: Blog
 intro: |
-    If you’re interested in design and front-end dev, you’ll enjoy this blog. If you’re a website owner looking for tips, check out the [Resources](/resources). Categories are [listed elsewhere](/categories).
-description: A blog for designers and front-end web developers. Covering topics such as accessibility, the web, Git and design from interesting companies such as Apple.
+    If you’re interested in design and frontend dev, you’ll enjoy this blog. If you’re a website owner looking for tips, check out the [Resources](/resources). Categories are [listed elsewhere](/categories).
+description: A blog for designers and frontend web developers. Covering topics such as accessibility, the web, Git and design from interesting companies such as Apple.
 layout: default
 noCta: true
 listing: true

--- a/src/site/category.html
+++ b/src/site/category.html
@@ -21,7 +21,7 @@ permalink: /category/{{ category | slug | safe }}.html
 {% elif category == 'Design' %}
     <p>Interaction design, user experience design, user interface design; design is a fascinating subject.
 {% elif category == 'Development' %}
-    <p>Front-end web development, from HTML, ARIA, CSS and JavaScript to Git and good development practices.
+    <p>Frontend web development, from HTML, ARIA, CSS and JavaScript to Git and good development practices.
 {% elif category == 'Markdown' %}
     <p>For me, Markdown is the only way to write for the web. In fact, it should be the defacto way to write, full-stop!
 {% elif category == 'Performance' %}

--- a/src/site/feeds/feeds.json
+++ b/src/site/feeds/feeds.json
@@ -1,5 +1,5 @@
 {
-  "description": "Articles on user experience design and front-end web development",
+  "description": "Articles on user experience design and frontend web development",
   "title": "tempertemper",
   "excludeFromSitemap": true
 }

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,5 +1,5 @@
 ---
-title: The web, design and front&#8209;end&nbsp;dev
+title: The web, design and front&#8209;end development
 intro: |
     I’m Martin, an interaction designer, front-end development and co-founder of [Frontend NE](https://2019.frontendne.co.uk). I [write](#writing) about the web, accessibility and inclusive, user-centred design. Here's some more [about me](/about) and [what I'm up to](/now).
 layout: home

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,7 +1,7 @@
 ---
-title: The web, design and front&#8209;end development
+title: The web, design and frontend development
 intro: |
-    I’m Martin, an interaction designer, front-end development and co-founder of [Frontend NE](https://2019.frontendne.co.uk). I [write](#writing) about the web, accessibility and inclusive, user-centred design. Here's some more [about me](/about) and [what I'm up to](/now).
+    I’m Martin, an interaction designer, frontend development and co-founder of [Frontend NE](https://2019.frontendne.co.uk). I [write](#writing) about the web, accessibility and inclusive, user-centred design. Here's some more [about me](/about) and [what I'm up to](/now).
 layout: home
 home: true
 cta: true

--- a/src/site/posts/2017-11-11--a-shift-in-focus.md
+++ b/src/site/posts/2017-11-11--a-shift-in-focus.md
@@ -27,7 +27,7 @@ Any energy I put into my site was spent converting the then-blog into a stand-al
 
 ## A shift of focus
 
-So you'll notice a huge shift in focus on this website. It's no centred on freelance and on-person-agency work; instead it's all about me as a designer and front-end developer. I'll be writing about my opinions, things I've been up to, design and development challenges I've overcome, that kind of thing.
+So you'll notice a huge shift in focus on this website. It's no centred on freelance and on-person-agency work; instead it's all about me as a designer and frontend developer. I'll be writing about my opinions, things I've been up to, design and development challenges I've overcome, that kind of thing.
 
 The [Resources section](/resources) will always be there for my clients and small website owners, and I don't plan to abandon it!
 

--- a/src/site/posts/2018-12-13--leaving-the-frontend-ne-meet-up.md
+++ b/src/site/posts/2018-12-13--leaving-the-frontend-ne-meet-up.md
@@ -5,7 +5,7 @@ intro: |
 date: 2018-12-13
 ---
 
-In early 2015 [Colin Oakley](https://twitter.com/htmlandbacon) asked if anyone he knew fancied setting up a meet-up for front-end web developers in the Newcastle area. [Sam Beckham](https://twitter.com/samdbeckham) and I replied in the affirmative and Frontend NE was a thing.
+In early 2015 [Colin Oakley](https://twitter.com/htmlandbacon) asked if anyone he knew fancied setting up a meet-up for frontend web developers in the Newcastle area. [Sam Beckham](https://twitter.com/samdbeckham) and I replied in the affirmative and Frontend NE was a thing.
 
 Fast-forward 4 years and it’s time for me to bow out of the meet-up.
 

--- a/src/site/posts/2019-01-02--a-new-years-resolution-for-2019.md
+++ b/src/site/posts/2019-01-02--a-new-years-resolution-for-2019.md
@@ -44,7 +44,7 @@ So this year I'm going to write and publish one article each week. A week feels 
 
 Ok, so it's a good idea. But we need some ground rules.
 
-- Articles can be about anything – they're likely to be about design and front-end development but I'm not going to hold a good idea back if it's outside of those subjects
+- Articles can be about anything – they're likely to be about design and frontend development but I'm not going to hold a good idea back if it's outside of those subjects
 - An article can be long or short – if a point *can* be delivered in 200 words, it *should* be delivered in 200 words
 - Articles will be published at the same time each week – Wednesday morning feels right, so let's go with that
 - I'll try to write one article each week, in line with the publishing schedule, but if inspiration takes me and I come up with more, I'm allowed to keep articles in my back pocket. This will also help prevent any [dip in quality](https://twitter.com/KevnGibsn/status/1080788095912607744)

--- a/src/site/posts/2019-06-14--implicit-aria-landmarks.md
+++ b/src/site/posts/2019-06-14--implicit-aria-landmarks.md
@@ -66,7 +66,7 @@ Also, the [same principle](https://www.w3.org/TR/html-aria/#footer) is *supposed
 
 ## The annoying thing
 
-Browser support is a thing in front-end development, and unfortunately/predictably if you want to [support Internet Explorer](https://www.html5accessibility.com) (and I'm not talking about IE8; I mean *any* version, including the most recent, IE11) you have to be explicit with your roles.
+Browser support is a thing in frontend development, and unfortunately/predictably if you want to [support Internet Explorer](https://www.html5accessibility.com) (and I'm not talking about IE8; I mean *any* version, including the most recent, IE11) you have to be explicit with your roles.
 
 But the thing that bugs me about all of this is that the WC3 page on [ARIA in HTML](https://www.w3.org/TR/html-aria/#h-note) tells us
 
@@ -90,4 +90,4 @@ I'll be continuing to add `role=""` attributes to elements that I want to be lan
 
 I'll also feel more comfortable using more than one `<header>` on a page, but it'll only be doing it inside either an `<article>` or `<section>` – I don't want any rogue landmarks being created!
 
-If only front-end development were easy!
+If only frontend development were easy!

--- a/src/site/posts/2019-06-26--getting-to-grips-with-git.md
+++ b/src/site/posts/2019-06-26--getting-to-grips-with-git.md
@@ -8,7 +8,7 @@ tags:
     - Git
 ---
 
-I bit the bullet and began playing around with [Git](https://git-scm.com) back in early 2012, around the time when front-end development started getting a bit more complicated than a text editor and an FTP client.
+I bit the bullet and began playing around with [Git](https://git-scm.com) back in early 2012, around the time when frontend development started getting a bit more complicated than a text editor and an FTP client.
 
 At that time, I wasn't using the command line for much, if anything; even things like compiling SCSS to CSS was done in a GUI like [CodeKit](https://codekitapp.com). So naturally I researched the best Mac app (the most excellent [Tower](https://www.git-tower.com/mac)) and stared there.
 
@@ -41,4 +41,3 @@ I'm perfectly happy dancing around on the the command line and, as I mentioned, 
 Now that it's gone I have no option but to get some muscle memory behind all of those commands I've been tentatively trialling over the last year.
 
 Command line Git, here I come!
-

--- a/src/site/posts/2019-07-02--design-and-dev-should-be-more-joined-up.md
+++ b/src/site/posts/2019-07-02--design-and-dev-should-be-more-joined-up.md
@@ -12,4 +12,4 @@ I've been catching up on some reading and came across this nugget in [The "D" in
 
 > To fix it we took the h3 and h4 off of the product names that were being displayed, and placed a visually hidden heading containing the product name before the price of the original and recommended products. This duplication of content was far from ideal, but it was necessary to fix the issue. In hindsight, we should have pressed for a design with a more logical reading order, which would have avoided a suboptimal hack
 
-I'm of the opinion that designers should be able to code. Or, at the minimum, designs should be shown to a front-end developer for critique on implementation (and revision) before they're shown to any stakeholders.
+I'm of the opinion that designers should be able to code. Or, at the minimum, designs should be shown to a frontend developer for critique on implementation (and revision) before they're shown to any stakeholders.

--- a/src/site/testimonials/martin-deane.md
+++ b/src/site/testimonials/martin-deane.md
@@ -2,10 +2,10 @@
 title: Martin Deane
 company: MyITEC
 intro: |
-    Martin himself has overseen the overall user experience, interface design and the front-end code. He's is easy to work with, professional and never fails to produce a quality end result; we’re looking forward to working with him on the next phase of MyITEC!
+    Martin himself has overseen the overall user experience, interface design and the frontend code. He's is easy to work with, professional and never fails to produce a quality end result; we’re looking forward to working with him on the next phase of MyITEC!
 website: http://myitec.com
 date: 2016-02-02
 feature: false
 ---
 
-> “ITEC graduates have long been without any post-qualification support, which is a problem the MyITEC project looks to solve. Martin from tempertemper has been involved since the outset, bringing on board a team of fellow freelancers to cover the branding and the ASP.NET back-end. Martin himself has overseen the overall user experience, interface design and the front-end code. Martin is easy to work with, professional and never fails to produce a quality end result; we’re looking forward to working with him on the next phase of MyITEC!”
+> “ITEC graduates have long been without any post-qualification support, which is a problem the MyITEC project looks to solve. Martin from tempertemper has been involved since the outset, bringing on board a team of fellow freelancers to cover the branding and the ASP.NET back-end. Martin himself has overseen the overall user experience, interface design and the frontend code. Martin is easy to work with, professional and never fails to produce a quality end result; we’re looking forward to working with him on the next phase of MyITEC!”

--- a/src/site/testimonials/ryan-davies.md
+++ b/src/site/testimonials/ryan-davies.md
@@ -2,10 +2,10 @@
 title: Ryan Davies
 company: Surge
 intro: |
-    Martin is an excellent front-end developer and UX designer. He's unafraid to challenge design directions for the good of the end-user, is reliable, trustworthy and a good addition to any team.
+    Martin is an excellent frontend developer and UX designer. He's unafraid to challenge design directions for the good of the end-user, is reliable, trustworthy and a good addition to any team.
 website: https://wearesurge.co
 date: 2018-08-11
 feature: true
 ---
 
-> “Martin's work with us over the years has been superb. He's an excellent front-end developer and is not afraid to challenge design directions for the good of the end-user. His HTML is clear and accessible, his CSS is well structured and easy to maintain, and his UX design abilities are not to be sniffed at. He's reliable, trustworthy and a great addition to any team; able to communicate ideas efficiently and—more importantly—tactfully.”
+> “Martin's work with us over the years has been superb. He's an excellent frontend developer and is not afraid to challenge design directions for the good of the end-user. His HTML is clear and accessible, his CSS is well structured and easy to maintain, and his UX design abilities are not to be sniffed at. He's reliable, trustworthy and a great addition to any team; able to communicate ideas efficiently and—more importantly—tactfully.”


### PR DESCRIPTION
- Reduces main heading (`<h1>`) size slightly
- Uses 'development' rather than 'dev' in homepage `<h1>`
- Removes hyphen from references to frontend development
