### PR TITLE
Calls to action wording tweaks

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
+- Makes contact CTA a bit less corporate sounding
+- Reduces unsubscribe message in newsletter sign up small print
+
 ----------
 
 

--- a/src/site/_includes/call-to-action.html
+++ b/src/site/_includes/call-to-action.html
@@ -15,7 +15,7 @@
         {% include "newsletter-signup.html" %}
     {% elif resource or testimonial or caseStudy %}
         <h2 id="{{ ctaLabel }}">Want to work with me?</h2>
-        <p>If you like what you’ve read and think we’d work well together, why not reach out and say hello?</p>
+        <p>If you like what you’ve read and think we’d work well together, I’d love to hear from you.</p>
         <a class="button" draggable="false" role="button" href="/contact">Contact me now</a>
     {% else %}
         <h2 id="{{ ctaLabel }}">Keep in the loop</h2>

--- a/src/site/_includes/newsletter-signup.html
+++ b/src/site/_includes/newsletter-signup.html
@@ -12,4 +12,4 @@
     <input type="submit" value="Subscribe now" />
 </form>
 
-<p><small><a href="/privacy-policy#newsletter">I don’t collect any data</a> on when, where or if people open the emails I send them. Your email will <strong>only</strong> be used to send you newsletters and will <strong>never</strong> be passed on. You can unsubscribe at any time via the link on every email.</small></p>
+<p><small><a href="/privacy-policy#newsletter">I don’t collect any data</a> on when, where or if people open the emails I send them. Your email will <strong>only</strong> be used to send you newsletters and will <strong>never</strong> be passed on. You can unsubscribe at any time.</small></p>


### PR DESCRIPTION
### Changes
- Makes contact CTA a bit less corporate sounding
- Reduces unsubscribe message in newsletter sign up small print
