### PR TITLE
Release version 5.11.1

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+----------
+
+
+## [5.11.1] - 2020-06-30
+
 ### Adds
 - Allows post/resource/testimonial/case study URL override parameter in front matter
 
@@ -18,8 +23,6 @@ All notable changes to this project will be documented in this file. The format 
 - Inserts non-breaking space into recent article title to fix problematic wrapping
 - Removes non breaking spaces (which aren't valid) from titles in feeds
 - Strips non breaking spaces from post/resource/testimonial/case study permalinks
-
-----------
 
 
 ## [5.11.0] - 2020-06-30

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Adds
+- Allows post/resource/testimonial/case study URL override parameter in front matter
+
+### Fixes
+- Inserts non-breaking space into recent article title to fix problematic wrapping
+- Removes non breaking spaces (which aren't valid) from titles in feeds
+- Strips non breaking spaces from post/resource/testimonial/case study permalinks
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -18,11 +18,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Adds
 - Allows post/resource/testimonial/case study URL override parameter in front matter
+- Inserts non-breaking space into recent article title to fix problematic wrapping
 
 ### Fixes
-- Inserts non-breaking space into recent article title to fix problematic wrapping
 - Removes non breaking spaces (which aren't valid) from titles in feeds
-- Strips non breaking spaces from post/resource/testimonial/case study permalinks
 
 
 ## [5.11.0] - 2020-06-30

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "tempertemper's website",
   "scripts": {
     "start": "gulp cleanSite && gulp buildAll && gulp serve",

--- a/src/site/_data/site.json
+++ b/src/site/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "http://github.com/tempertemper/tempertemper-website",

--- a/src/site/case-studies/case-studies.json
+++ b/src/site/case-studies/case-studies.json
@@ -2,5 +2,5 @@
   "layout": "case-study.html",
   "hideIntro": true,
   "tags" : ["case_study"],
-  "permalink": "portfolio/{{ title | slug | safe }}.html"
+  "permalink": "portfolio/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
 }

--- a/src/site/case-studies/case-studies.json
+++ b/src/site/case-studies/case-studies.json
@@ -2,5 +2,5 @@
   "layout": "case-study.html",
   "hideIntro": true,
   "tags" : ["case_study"],
-  "permalink": "portfolio/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
+  "permalink": "portfolio/{{ customURL if customURL else title | slug | safe }}.html"
 }

--- a/src/site/feeds/atom.html
+++ b/src/site/feeds/atom.html
@@ -19,7 +19,7 @@ permalink: feeds/main.xml
     </author>
     {%- for post in collections.post | reverse %}
     <entry>
-        <title>{{ post.data.title | smart | safe }}</title>
+        <title>{{ post.data.title | smart | safe | replace("&nbsp;", " ") }}</title>
         <link href="{{ site.url }}{{ post.url | replace (".html", "") }}" />
         <id>{{ site.url }}{{ post.url | replace (".html", "") }}</id>
         <published>{{ post.date | rssDate }}</published>

--- a/src/site/feeds/json.html
+++ b/src/site/feeds/json.html
@@ -20,7 +20,7 @@ permalink: feeds/main.json
       "id": "{{ loop.revindex }}",
       "date_published": "{{ post.date | rssDate }}",
       {%- if post.updated %}"date_modified": "{{ post.updated | rssDate }}",{%- endif %}
-      "title": "{{ post.data.title | smart | safe }}",
+      "title": "{{ post.data.title | smart | safe | replace("&nbsp;", " ") }}",
       "summary": "{{ post.data.intro | markdown | safe | striptags }}",
       {%- set postTags = post.data.tags | tagsOnPage %}
       {%- if postTags.length > 0  %}
@@ -37,4 +37,3 @@ permalink: feeds/main.json
   {%- endfor %}
   ]
 }
-

--- a/src/site/posts/2020-06-30--front-end-frontend-or-front-end.md
+++ b/src/site/posts/2020-06-30--front-end-frontend-or-front-end.md
@@ -1,5 +1,6 @@
 ---
 title: "'Front-end', 'frontend' or 'front&nbsp;end'?"
+customURL: front-end-front-end-or-front-end
 intro: |
     As a frontend developer, something has always bothered me. How on earth do you spell 'frontend'!? Or should that be 'front-end'? Or 'front end'…?
 date: 2020-06-30

--- a/src/site/posts/2020-06-30--front-end-frontend-or-front-end.md
+++ b/src/site/posts/2020-06-30--front-end-frontend-or-front-end.md
@@ -1,5 +1,5 @@
 ---
-title: "'Front-end', 'frontend' or 'front end'?"
+title: "'Front-end', 'frontend' or 'front&nbsp;end'?"
 intro: |
     As a frontend developer, something has always bothered me. How on earth do you spell 'frontend'!? Or should that be 'front-end'? Or 'front end'…?
 date: 2020-06-30
@@ -8,7 +8,7 @@ tags:
     - Development
 ---
 
-As a frontend developer, something has always bothered me. How do you spell 'frontend'!? So at the weekend, I ran [my first Twitter Poll](https://twitter.com/tempertemper/status/1276605361605263361?s=21), asking:
+As a frontend&nbsp;developer, something has always bothered me. How do you spell 'frontend'!? So at the weekend, I ran [my first Twitter Poll](https://twitter.com/tempertemper/status/1276605361605263361?s=21), asking:
 
 > So is it ‘front-end', ‘frontend’ or 'front end’?
 

--- a/src/site/posts/posts.json
+++ b/src/site/posts/posts.json
@@ -2,5 +2,5 @@
   "layout": "article.html",
   "hideIntro": true,
   "tags": ["post"],
-  "permalink": "blog/{{ title | slug | safe }}.html"
+  "permalink": "blog/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
 }

--- a/src/site/posts/posts.json
+++ b/src/site/posts/posts.json
@@ -2,5 +2,5 @@
   "layout": "article.html",
   "hideIntro": true,
   "tags": ["post"],
-  "permalink": "blog/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
+  "permalink": "blog/{{ customURL if customURL else title | slug | safe }}.html"
 }

--- a/src/site/resources/resources.json
+++ b/src/site/resources/resources.json
@@ -2,5 +2,5 @@
   "layout": "article.html",
   "hideIntro": true,
   "tags" : ["resource"],
-  "permalink": "resources/{{ title | slug | safe }}.html"
+  "permalink": "resources/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
 }

--- a/src/site/resources/resources.json
+++ b/src/site/resources/resources.json
@@ -2,5 +2,5 @@
   "layout": "article.html",
   "hideIntro": true,
   "tags" : ["resource"],
-  "permalink": "resources/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
+  "permalink": "resources/{{ customURL if customURL else title | slug | safe }}.html"
 }

--- a/src/site/testimonials/testimonials.json
+++ b/src/site/testimonials/testimonials.json
@@ -2,5 +2,5 @@
   "layout": "testimonial.html",
   "tags" : "testimonial",
   "hideIntro": true,
-  "permalink": "testimonials/{{ title | slug | safe }}.html"
+  "permalink": "testimonials/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
 }

--- a/src/site/testimonials/testimonials.json
+++ b/src/site/testimonials/testimonials.json
@@ -2,5 +2,5 @@
   "layout": "testimonial.html",
   "tags" : "testimonial",
   "hideIntro": true,
-  "permalink": "testimonials/{{ customURL if customURL else title | slug | safe | replace("&nbsp;", "-") }}.html"
+  "permalink": "testimonials/{{ customURL if customURL else title | slug | safe }}.html"
 }


### PR DESCRIPTION
### Adds
- Allows post/resource/testimonial/case study URL override parameter in front matter

### Fixes
- Inserts non-breaking space into recent article title to fix problematic wrapping
- Removes non breaking spaces (which aren't valid) from titles in feeds
- Strips non breaking spaces from post/resource/testimonial/case study permalinks
