### PR TITLE
Removes explicit ARIA landmark roles

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -18,6 +18,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changes
 - Uses smart filter for apostrophes, etc. in post titles in the common feed content
+- Styles `header`, `navigation`, `main` and `footer` elements rather than their equivalent ARIA roles
+
+### Removes
+- Removes `aria-hidden` attribute where there's already a `hidden` attribute
+- Removes explicit ARIA roles of `banner`, `navigation`, `main` and `contentinfo`
 
 ----------
 

--- a/src/scss/components/_content.scss
+++ b/src/scss/components/_content.scss
@@ -1,6 +1,6 @@
 @media (min-width: $l) {
 
-  [role="main"] {
+  main {
     @include layout($wide-layout);
     @include pre(1 of 6);
     width: span(4 of 6);

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -1,4 +1,4 @@
-[role="contentinfo"] {
+.footer {
   clear: both;
   font-family: $font--heading;
   padding-bottom: 1em;

--- a/src/scss/components/_header.scss
+++ b/src/scss/components/_header.scss
@@ -1,4 +1,4 @@
-[role="banner"] {
+.header {
   padding-top: 1em;
   display: flex;
   justify-content: space-between;

--- a/src/scss/legacy/_ie.scss
+++ b/src/scss/legacy/_ie.scss
@@ -16,7 +16,7 @@
     overflow: hidden;
   }
 
-  [role="contentinfo"] [href="https://twitter.com/tempertemper"] {
+  .footer [href="https://twitter.com/tempertemper"] {
 
     &:before {
       content: 'Twitter:';

--- a/src/scss/legacy/_print.scss
+++ b/src/scss/legacy/_print.scss
@@ -15,7 +15,7 @@
   .button,
   .subscribe,
   .paging,
-  [role="navigation"] {
+  .navigation {
     display: none;
   }
 

--- a/src/site/_includes/footer.html
+++ b/src/site/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer role="contentinfo">
+<footer class="footer">
     <nav aria-label="repeated primary">
         {% include "navigation-primary.html" %}
     </nav>

--- a/src/site/_includes/header.html
+++ b/src/site/_includes/header.html
@@ -2,7 +2,7 @@
     <a href="/" class="logo" title="Return to homepage">
         {% include "svg/tempertemper-logo.svg" %}
     </a>
-    <nav role="navigation" aria-label="primary">
+    <nav class="navigation" aria-label="primary">
         {% include "navigation-primary.html" %}
     </nav>
 </header>

--- a/src/site/_includes/header.html
+++ b/src/site/_includes/header.html
@@ -1,4 +1,4 @@
-<header role="banner">
+<header class="header">
     <a href="/" class="logo" title="Return to homepage">
         {% include "svg/tempertemper-logo.svg" %}
     </a>

--- a/src/site/_includes/newsletter-signup.html
+++ b/src/site/_includes/newsletter-signup.html
@@ -1,5 +1,5 @@
 <form class="subscribe" id="subscribe" name="newsletter" action="/newsletter/confirm-email" method="POST" data-netlify="true" netlify-honeypot="bot-field" novalidate>
-    <div hidden aria-hidden="true">
+    <div hidden>
         <label>
             Don’t fill this out if you're human:
             <input name="bot-field" />

--- a/src/site/_layouts/base.html
+++ b/src/site/_layouts/base.html
@@ -6,7 +6,7 @@
             <div class="page-wrapper">
                 <a href="#main" tabindex="0" class="skip-to-content">Skip to main content</a>
                 {% include "header.html" %}
-                <main id="main" role="main">
+                <main id="main">
                     {{ content | safe }}
                     {% if cta %}
                         {% include "call-to-action.html" %}


### PR DESCRIPTION
### Changes
- Styles `header`, `navigation`, `main` and `footer` elements rather than their equivalent ARIA roles

### Removes
- Removes `aria-hidden` attribute where there's already a `hidden` attribute
- Removes explicit ARIA roles of `banner`, `navigation`, `main` and `contentinfo`
