### PR TITLE
Code colour contrast fixes

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
+- Uses lighter background for code in light mode
+
+### Fixes
+- Addresses colour contrast for inline code inside links
+- Tidies focus styling for inline code inside links
+- Fixes colour contrast for syntax highlighted code in both light and dark modes
+
 ----------
 
 

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -26,6 +26,21 @@ $colour-dark-mode-highlight: #3D3D3D;
 $colour-dark-mode-white: #f2f2f2;
 $colour-dark-mode-black: #1f1f22;
 
+// Code colours
+$colour-code-grey: #534f54;
+$colour-code-magenta: #dd0341;
+$colour-code-purple: #6d5ad8;
+$colour-code-cyan: #147685;
+$colour-code-yellow: #7c6c03;
+
+// Dark mode code colours
+$colour-dark-mode-code-grey: #adacaf;
+$colour-dark-mode-code-magenta: #fc88a9;
+$colour-dark-mode-code-purple: #afa4ea;
+$colour-dark-mode-code-cyan: #5bd4e6;
+$colour-dark-mode-code-yellow: #fce766;
+
+
 // General styles
 $border-radius-default: 5px;
 $section-spacing: 3em;

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -1,9 +1,11 @@
 code,
 kbd,
 pre {
-  @include dark-mode ($colour-dark-mode-black);
-  background-color: $colour-dark-mode-highlight;
-  color: $colour-dark-mode-white;
+  background-color: $colour-dark-mode-white;
+
+  @include dark-mode() {
+    @include dark-mode ($colour-dark-mode-black, $colour-dark-mode-white);
+  }
 }
 
 code,
@@ -41,11 +43,15 @@ pre {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #69676c;
+  color: $colour-code-grey;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-grey;
+  }
 }
 
 .token.punctuation {
-  color: #f8f8f2;
+  color: inherit;
 }
 
 .token.property,

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -59,12 +59,20 @@ pre {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #fc608d;
+  color: $colour-code-magenta;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-magenta;
+  }
 }
 
 .token.boolean,
 .token.number {
-  color: #9587e3;
+  color: $colour-code-purple;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-purple;
+  }
 }
 
 .token.selector,
@@ -73,7 +81,11 @@ pre {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #5bd4e6;
+  color: $colour-code-cyan;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-cyan;
+  }
 }
 
 .token.operator,
@@ -82,22 +94,38 @@ pre {
 .language-css .token.string,
 .style .token.string,
 .token.variable {
-  color: #5bd4e6;
+  color: $colour-code-cyan;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-cyan;
+  }
 }
 
 .token.atrule,
 .token.attr-value,
 .token.function {
-  color: #fce766;
+  color: $colour-code-yellow;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-yellow;
+  }
 }
 
 .token.keyword {
-  color: #fc608d;
+  color: $colour-code-magenta;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-magenta;
+  }
 }
 
 .token.regex,
 .token.important {
-  color: #fce766;
+  color: $colour-code-yellow;
+
+  @include dark-mode() {
+    color: $colour-dark-mode-code-yellow;
+  }
 }
 
 .token.important,

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -1,4 +1,5 @@
 @mixin text-link {
+  border-radius: $border-radius-default/2;
 
   &:link,
   &:visited {
@@ -46,8 +47,18 @@ a {
     }
   }
 
+  &:focus > code {
+    background-color: $colour-primary;
+    padding-top: .22em;
+    padding-bottom: .04em;
+  }
+
   > code {
-    @include dark-mode($color: $colour-dark-mode-primary);
-    color: $colour-dark-mode-primary-lighter;
+    color: $colour-primary-darker;
+
+    @include dark-mode() {
+      @include dark-mode($color: $colour-dark-mode-primary);
+      color: $colour-dark-mode-primary-lighter;
+    }
   }
 }


### PR DESCRIPTION
### Changes
- Uses lighter background for code in light mode

### Fixes
- Addresses colour contrast for inline code inside links
- Tidies focus styling for inline code inside links
- Fixes colour contrast for syntax highlighted code in both light and dark modes
