### PR TITLE
Release version 5.11.9

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Removes
+- Removes navigation link dividers
+
 ### Fixes
 - Gives navigation links a minimum height to be better touch targets
 

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+----------
+
+
+## [5.11.9] - 2020-09-09
+
 ### Changes
 - Gives footer address a different role – presentation rather than group
 
@@ -19,8 +24,6 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixes
 - Gives navigation links a minimum height to be better touch targets
-
-----------
 
 
 ## [5.11.8] - 2020-09-09

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixes
+- Gives navigation links a minimum height to be better touch targets
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
+- Gives footer address a different role – presentation rather than group
+
 ### Removes
 - Removes navigation link dividers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.11.8",
+  "version": "5.11.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.11.8",
+  "version": "5.11.9",
   "description": "tempertemper's website",
   "scripts": {
     "start": "gulp cleanSite && gulp buildAll && gulp serve",

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -70,9 +70,11 @@
   }
 
   a {
-    display: inline-block;
+    display: inline-flex;
     padding-left: .1em;
     padding-right: .1em;
+    min-height: 48px;
+    align-items: center;
   }
 }
 

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -57,22 +57,10 @@
     margin-top: 0;
   }
 
-  &:after {
-    content: '/';
-    display: inline-block;
-  }
-
-  &:last-child {
-
-    &:after {
-      content: none;
-    }
-  }
-
   a {
     display: inline-flex;
-    padding-left: .1em;
-    padding-right: .1em;
+    padding-left: .25em;
+    padding-right: .25em;
     min-height: 48px;
     align-items: center;
   }

--- a/src/site/_data/site.json
+++ b/src/site/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "5.11.8",
+  "version": "5.11.9",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "http://github.com/tempertemper/tempertemper-website",

--- a/src/site/_includes/footer.html
+++ b/src/site/_includes/footer.html
@@ -13,7 +13,7 @@
         </a>
     </div>
     <p class="copyright">&copy;&nbsp;copyright 2009&nbsp;to&nbsp;{{ "" | getCurrentYear }}</p>
-    <address class="adr" role="group">
+    <address class="adr" role="presentation">
         <span class="org">tempertemper Web Design Ltd</span>,
         <span class="extended-address">Clavering House</span>,
         <span class="street-address">Clavering Place</span>,


### PR DESCRIPTION
### Changes
- Gives footer address a different role – presentation rather than group

### Removes
- Removes navigation link dividers

### Fixes
- Gives navigation links a minimum height to be better touch targets
