### PR TITLE
Focus text colour contrast fixes

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -18,6 +18,11 @@ All notable changes to this project will be documented in this file. The format 
 - Updates Markdown-it packages
 - Updates Browsersync, Del and Version Bump npm packages
 
+### Fixes
+- Tweaks top padding on code in links
+- Matches code in links' colours to rest of link
+- Makes link text black on focus in Dark Mode, passing AA colour contrast
+
 ----------
 
 

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -48,7 +48,7 @@ a {
   }
 
   &:focus > code {
-    padding-top: .22em;
+    padding-top: .21em;
     padding-bottom: .04em;
   }
 

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -26,7 +26,7 @@
 
     > code {
       background-color: $colour-primary-lighter;
-      color: $white;
+      color: inherit;
       @include dark-mode($background: $colour-dark-mode-primary);
       padding-bottom: 0;
     }
@@ -48,7 +48,6 @@ a {
   }
 
   &:focus > code {
-    background-color: $colour-primary;
     padding-top: .22em;
     padding-bottom: .04em;
   }

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -22,7 +22,7 @@
     background-color: $colour-primary-lighter;
     color: $white;
     text-decoration: none;
-    @include dark-mode($background: $colour-dark-mode-primary, $color: $white);
+    @include dark-mode($background: $colour-dark-mode-primary, $color: $black);
 
     > code {
       background-color: $colour-primary-lighter;


### PR DESCRIPTION
### Fixes
- Tweaks top padding on code in links
- Matches code in links' colours to rest of link
- Makes link text black on focus in Dark Mode, passing AA colour contrast
