### PR TITLE
Removes filepath wildcards as not supported

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1084,18 +1084,6 @@
 ## Spam redirects
 
 [[redirects]]
-  from = "*/*.sql"
-  to = "/404"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/*.sql.gz"
-  to = "/404"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "/security.txt"
   to = "/.well-known/security.txt"
   status = 301


### PR DESCRIPTION
Netlify doesn't support wildcard filename redirects yet, so `*.sql`, etc. don't work