### PR TITLE
Light mode scrollbar fix and some colour modifications

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changes
 - lightens logo underscore
+- Changes 'light' Light Mode colour variable to 'lightest' and introduces new 'light'
 
 ----------
 

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
+- lightens logo underscore
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file. The format 
 - lightens logo underscore
 - Changes 'light' Light Mode colour variable to 'lightest' and introduces new 'light'
 
+### Fixes
+- Fixes scrollbar colour in Light Mode so that it's dark against the white background instead of white
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Changes
 - lightens logo underscore
 - Changes 'light' Light Mode colour variable to 'lightest' and introduces new 'light'
+- Uses original brand blue for top and bottom strips
 
 ### Fixes
 - Fixes scrollbar colour in Light Mode so that it's dark against the white background instead of white

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -66,7 +66,7 @@
 }
 
 @mixin highlight-box {
-  background-color: $colour-primary-light;
+  background-color: $colour-primary-lightest;
   @include dark-mode(
     $background: $colour-dark-mode-highlight,
     $color: $colour-dark-mode-white
@@ -117,7 +117,7 @@
 
 @mixin embedded-media {
   border-radius: $border-radius-default;
-  background-color: $colour-primary-light;
+  background-color: $colour-primary-lightest;
   @include dark-mode($background: $colour-dark-mode-highlight);
   display: block;
   box-shadow: 0 0 .25em lighten($black, 85%);

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -10,8 +10,9 @@ $xl: 85em;
 $black: #0b0c0c;
 $white: #fff;
 
+$colour-original: #0097db;
+
 // Primary colours
-// $colour-primary: #0097db;
 $colour-primary: #007cba;
 $colour-primary-lighter: #008dd1;
 $colour-primary-light: #09adfc;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -14,7 +14,8 @@ $white: #fff;
 // $colour-primary: #0097db;
 $colour-primary: #007cba;
 $colour-primary-lighter: #008dd1;
-$colour-primary-light: #e6f7ff;
+$colour-primary-light: #09adfc;
+$colour-primary-lightest: #e6f7ff;
 $colour-primary-darker: #0073ab;
 
 // Dark mode colours

--- a/src/scss/components/_logo.scss
+++ b/src/scss/components/_logo.scss
@@ -20,6 +20,10 @@
     }
   }
 
+  .underscore {
+    fill: $colour-original;
+  }
+
   &:focus {
 
     .underscore {

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -1,8 +1,8 @@
 html,
 body {
   overflow-x: hidden;
-  background-color: $colour-primary;
-  @include dark-mode($background: $colour-dark-mode-primary);
+  background-color: $colour-primary-light;
+  @include dark-mode($background: $colour-original);
 }
 
 body {


### PR DESCRIPTION
### Changes
- lightens logo underscore
- Changes 'light' Light Mode colour variable to 'lightest' and introduces new 'light'
- Uses original brand blue for top and bottom strips

### Fixes
- Fixes scrollbar colour in Light Mode so that it's dark against the white background instead of white
