### PR TITLE
`aria-label` audit for sections and read more

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file. The format 
 ### Changes
 - Uses `aria-labelledby` instead of `aria-label` for sections where appropriate
 
+### Fixes
+- Uses same text testimonial 'read more' visually and programmatically
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
+- Uses `aria-labelledby` instead of `aria-label` for sections where appropriate
+
 ----------
 
 

--- a/src/site/_includes/more-posts.html
+++ b/src/site/_includes/more-posts.html
@@ -14,8 +14,8 @@
     {%- set linkToList = '/portfolio/' %}
     {%- set items = collections.case_study %}
 {%- endif %}
-<section aria-label="Further reading" class="teaser">
-    <h2>More {{ typeOfThing }}</h2>
+<section aria-labelledby="further-reading-heading" class="teaser">
+    <h2 id="further-reading-heading">More {{ typeOfThing }}</h2>
     <p>Here are a couple more {{ typeOfThing }} for you to enjoy. If that's not enough, have a look at <a href="{{ linkToList }}">the full list</a>.</p>
     <ol class="hfeed index-list" reversed>
         {%- set limit = 2 %}

--- a/src/site/_layouts/home.html
+++ b/src/site/_layouts/home.html
@@ -18,7 +18,7 @@ layout: base.html
     {{ content | safe }}
 </article>
 
-<section aria-label="Writing" class="teaser">
+<section aria-labelledby="writing" class="teaser">
     <h2 id="writing">Writing</h2>
     <p>If you prefer to dive straight in rather than <a href="/blog/">see the full blog</a>, here are a couple of my favourite articles from the last few months to get you started.</p>
     <ol class="index-list" reversed>
@@ -31,7 +31,7 @@ layout: base.html
     </ol>
 </section>
 
-<section aria-label="Subjects">
+<section aria-labelledby="my-favourite-subjects">
     <h2 id="my-favourite-subjects">Subjects</h2>
     <p>There are a few topics that really interest me:</p>
     <ul>

--- a/src/site/testimonials.html
+++ b/src/site/testimonials.html
@@ -17,7 +17,7 @@ listing: true
                 &#8220;{{ testimonial.data.intro | markdown | safe  | striptags(true) }}&#8221;
             </blockquote>
             <div class="read-more">
-                <a href="{{ testimonial.url | replace(".html", "") }}" aria-label="View full testimonial from {{ testimonial.data.title }}">View full testimonial</a>
+                <a href="{{ testimonial.url | replace(".html", "") }}">View full testimonial<span class="visually-hidden"> from {{ testimonial.data.title }}</span></a>
             </div>
         </li>
     {% endfor %}


### PR DESCRIPTION
### Changes
- Uses `aria-labelledby` instead of `aria-label` for sections where appropriate

### Fixes
- Uses same text testimonial 'read more' visually and programmatically
