### PR TITLE
A couple of git stash edits, including linking between two articles

### DIFF
--- a/src/site/posts/2021-02-04--choosing-a-stash-from-the-list.md
+++ b/src/site/posts/2021-02-04--choosing-a-stash-from-the-list.md
@@ -3,6 +3,7 @@ title: Choosing a stash from the list
 intro: |
     Viewing all of a Git repository's stashes and choosing one from the list is the next step I took in my Git stash on the command line journey.
 date: 2021-02-04
+updated: 2021-02-09
 tags:
     - Git
 ---
@@ -13,7 +14,7 @@ tags:
 git stash list
 ```
 
-This brings up a list of all of the stashes in your current repository; to choose a particular stash, all you have to do is find the index of the stash:
+This brings up a list of all of the stashes in your current repository (which is much easier understand if you've [named your stashes](/blog/giving-your-stash-a-name)); to choose a particular stash, all you have to do is find the index of the stash:
 
 1. View your list of stashes
 2. Copy the stash index number (which looks something like `stash@{2}`)

--- a/src/site/posts/2021-02-08--applying-a-git-stash-non-destructively.md
+++ b/src/site/posts/2021-02-08--applying-a-git-stash-non-destructively.md
@@ -1,7 +1,7 @@
 ---
 title: Applying a Git stash non-destructively
 intro: |
-    I almost always want to delete a stash when I apply it, but if for some reason you need to keep the stash around, Git lets you do that.
+    You'll almost always want to delete a stash when you apply it, but if for some reason you need to keep the stash around, Git lets you do that.
 date: 2021-02-08
 tags:
     - Git


### PR DESCRIPTION
- Fixes mixed up tense in `git stash apply` post
- Links to `git stash save` post from `git stash list` post (as the 'save' post wasn't live when the 'list' post was published)