### PR TITLE
Link focus styling

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+- Adds focus outline to links, consistent with form focus styling
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
 - Adds focus outline to links, consistent with form focus styling
+- Adds focus outline to 'skip to main content' link, consistent with other focus styling
 
 ----------
 

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -21,10 +21,11 @@
   &:focus {
     background-color: $colour-primary-lighter;
     color: $white;
-    box-shadow: 0 0 0 2px $colour-primary-lighter;
+    box-shadow: 0 0 0 1px $colour-primary-lighter,  0 0 0 4px $black;
+    box-decoration-break: clone;
     @include dark-mode() {
       background-color: $colour-dark-mode-primary;
-      box-shadow: 0 0 0 2px $colour-dark-mode-primary;
+      box-shadow: 0 0 0 1px $colour-dark-mode-primary, 0 0 0 4px $white;
       color: $black;
     }
 

--- a/src/scss/components/_skip-to-content.scss
+++ b/src/scss/components/_skip-to-content.scss
@@ -3,19 +3,18 @@
   font-family: $font--heading;
 
   &:focus {
-    border-radius: 0;
-    top: 0;
-    left: 0;
+    top: .5em;
+    left: .25em;
     overflow: visible;
     clip: initial;
     height: auto;
     width: auto;
     margin: 0;
-    box-shadow: 0 0 .4em .2em $colour-dark-mode-black;
+    box-shadow: 0 0 0 3px $black, 0 0 .4em .0em $colour-dark-mode-black;
     padding: 0.5em .5em;
 
     @include dark-mode() {
-      box-shadow: .2em .2em .4em .2em $colour-dark-mode-black;
+      box-shadow: 0 0 0 3px $white, .2em .2em .4em .1em $colour-dark-mode-black;
     }
   }
 }


### PR DESCRIPTION
### Changes
- Adds focus outline to links, consistent with form focus styling
- Adds focus outline to 'skip to main content' link, consistent with other focus styling
