### PR TITLE
Colour consistency and simplification

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -13,10 +13,17 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changes
 - Link focus only adds outline, no colour changes
+- Renames lightest Light Mode colour variable to be consistent with Dark Mode
+- Lightens Light Mode hightlight colour slightly
+- Uses `colour-primary` for every default state in Light Mode
+- Simplifies `::selection` colours
+- Simplifies hidden page background colour styling
+- All Dark Mode hover states lighten the blue
 
 ### Removes
 - Removes unnecessary image link styling
 - Gets rid of AAA primary colour for Light Mode
+- Removes unused `colour-primary-light` colour variable
 
 ----------
 

--- a/.changelog
+++ b/.changelog
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Removes
 - Removes unnecessary image link styling
+- Gets rid of AAA primary colour for Light Mode
 
 ----------
 

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -69,23 +69,15 @@
 }
 
 @mixin highlight-box {
-  background-color: $colour-primary-lightest;
-  @include dark-mode($background: $colour-dark-mode-highlight, $color: $colour-dark-mode-white);
+  background-color: $colour-primary-highlight;
+  @include dark-mode($background: $colour-dark-mode-highlight);
   border-radius: $border-radius-default;
   padding: 1em;
 
   a {
-    color: $colour-primary-darker;
-    @include dark-mode($color: $colour-dark-mode-primary-lighter);
-
-    &:hover,
-    &:active {
-      color: $colour-primary-lighter;
-      @include dark-mode($color: $colour-dark-mode-primary);
-    }
 
     &:focus {
-      background-color: $colour-primary-lightest;
+      background-color: $colour-primary-highlight;
       @include dark-mode($background: $colour-dark-mode-highlight);
     }
   }
@@ -113,7 +105,7 @@
 
 @mixin embedded-media {
   border-radius: $border-radius-default;
-  background-color: $colour-primary-lightest;
+  background-color: $colour-primary-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
   display: block;
   box-shadow: 0 0 .25em lighten($black, 85%);

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -10,10 +10,9 @@ $xl: 85em;
 $black: #0b0c0c;
 $white: #fff;
 
-$colour-original: #0097db;
-
 // Primary colours
-$colour-primary: #007cba;
+// $colour-primary: #007cba;
+$colour-primary: #0097db;
 $colour-primary-lighter: #008dd1;
 $colour-primary-light: #09adfc;
 $colour-primary-lightest: #e6f7ff;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -14,16 +14,15 @@ $white: #fff;
 // $colour-primary: #007cba;
 $colour-primary: #0097db;
 $colour-primary-lighter: #008dd1;
-$colour-primary-light: #09adfc;
-$colour-primary-lightest: #e6f7ff;
 $colour-primary-darker: #0073ab;
+$colour-primary-highlight: #ebf8ff;
 
 // Dark mode colours
 $colour-dark-mode-primary: #00a0f0;
 $colour-dark-mode-primary-lighter: #19b3ff;
 $colour-dark-mode-primary-darker: #008fd6;
-$colour-dark-mode-main: #2c2c2c;
 $colour-dark-mode-highlight: #3d3d3d;
+$colour-dark-mode-main: #2c2c2c;
 $colour-dark-mode-white: #f2f2f2;
 $colour-dark-mode-black: #1f1f22;
 

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -38,8 +38,7 @@
   &:hover {
     border-color: $colour-primary-darker;
     background-color: $colour-primary-darker;
-    @include dark-mode() {
-      background-color: $colour-dark-mode-primary-lighter;
+    @include dark-mode($background: $colour-dark-mode-primary-lighter) {
       border-color: $colour-dark-mode-primary-lighter;
     }
   }

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -23,11 +23,9 @@ input {
 
   &:focus {
     box-shadow: 0 0 0 3px $black;
-    border-color: $colour-primary;
 
     @include dark-mode() {
       box-shadow: 0 0 0 3px $white;
-      border-color: $colour-dark-mode-primary;
     }
   }
 }

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -1,6 +1,6 @@
 ::selection {
-  background: $colour-primary-lighter;
-  @include dark-mode($background: $colour-dark-mode-primary, $color: $black);
+  background: $colour-primary;
+  @include dark-mode($color: $black);
   color: $white;
 }
 

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -10,7 +10,7 @@
   &:hover,
   &:active {
     color: $colour-primary-darker;
-    @include dark-mode($color: $colour-dark-mode-primary-darker);
+    @include dark-mode($color: $colour-dark-mode-primary-lighter);
 
     > code {
       color: $colour-dark-mode-primary;

--- a/src/scss/components/_logo.scss
+++ b/src/scss/components/_logo.scss
@@ -21,7 +21,7 @@
   }
 
   .underscore {
-    fill: $colour-original;
+    fill: $colour-primary;
   }
 }
 

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -1,8 +1,7 @@
 html,
 body {
   overflow-x: hidden;
-  background-color: $colour-primary-light;
-  @include dark-mode($background: $colour-primary);
+  background-color: $colour-primary;
 }
 
 body {

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -2,7 +2,7 @@ html,
 body {
   overflow-x: hidden;
   background-color: $colour-primary-light;
-  @include dark-mode($background: $colour-original);
+  @include dark-mode($background: $colour-primary);
 }
 
 body {


### PR DESCRIPTION
### Changes
- Renames lightest Light Mode colour variable to be consistent with Dark Mode
- Lightens Light Mode hightlight colour slightly
- Uses `colour-primary` for every default state in Light Mode
- Simplifies `::selection` colours
- Simplifies hidden page background colour styling
- All Dark Mode hover states lighten the blue

### Removes
- Removes unused `colour-primary-light` colour variable
