### PR TITLE
High contrast colour scheme

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixes
+- Corrects spelling of 'colour' in dark mode mixin
+
 ### Removes
 - Tidies up Dark Mode @includes
 

--- a/.changelog
+++ b/.changelog
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixes
 - Corrects spelling of 'colour' in dark mode mixin
+- Makes scroll markers in light mode dark again
 
 ### Removes
 - Tidies up Dark Mode @includes

--- a/.changelog
+++ b/.changelog
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Adds
 - Creates new main colour variable for consistency with Dark Mode colour palette
 - Adds anti-aliasing to dark mode text
+- Adds high contrast mode
 
 ### Changes
 - Uses `colour-` prefix for `$black` colour variable

--- a/.changelog
+++ b/.changelog
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Adds
 - Creates new main colour variable for consistency with Dark Mode colour palette
+- Adds anti-aliasing to dark mode text
 
 ### Changes
 - Uses `colour-` prefix for `$black` colour variable
@@ -22,6 +23,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixes
 - Corrects spelling of 'colour' in dark mode mixin
 - Makes scroll markers in light mode dark again
+- Removes letter spacing in dark mode to fix multi-word link underlines
 
 ### Removes
 - Tidies up Dark Mode @includes

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Removes
+- Tidies up Dark Mode @includes
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
+- Uses `colour-` prefix for `$black` colour variable
+
 ### Fixes
 - Corrects spelling of 'colour' in dark mode mixin
 

--- a/.changelog
+++ b/.changelog
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changes
 - Uses `colour-` prefix for `$black` colour variable
+- Uses `colour-` prefix for `$white` colour variable
 
 ### Fixes
 - Corrects spelling of 'colour' in dark mode mixin

--- a/.changelog
+++ b/.changelog
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Changes
 - Uses `colour-` prefix for `$black` colour variable
 - Uses `colour-` prefix for `$white` colour variable
+- Renames `$colour-primary-highlight` to `$colour-highlight`
 
 ### Fixes
 - Corrects spelling of 'colour' in dark mode mixin

--- a/.changelog
+++ b/.changelog
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. The format 
 - Corrects spelling of 'colour' in dark mode mixin
 - Makes scroll markers in light mode dark again
 - Removes letter spacing in dark mode to fix multi-word link underlines
+- Fixes spacing inconsistency with `@includes`
 
 ### Removes
 - Tidies up Dark Mode @includes

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Adds
+- Creates new main colour variable for consistency with Dark Mode colour palette
+
 ### Changes
 - Uses `colour-` prefix for `$black` colour variable
 - Uses `colour-` prefix for `$white` colour variable

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -1,18 +1,18 @@
-@mixin dark-mode($background: null, $color: null) {
+@mixin dark-mode($background: null, $colour: null) {
 
   @media screen and (prefers-color-scheme: dark) {
 
-    @if ($background != null and $color != null) {
+    @if ($background != null and $colour != null) {
       background-color: $background;
-      color: $color;
+      color: $colour;
       @content;
     }
-    @else if ($background != null and $color == null) {
+    @else if ($background != null and $colour == null) {
       background-color: $background;
       @content;
     }
-    @else if ($color != null and $background == null) {
-      color: $color;
+    @else if ($colour != null and $background == null) {
+      color: $colour;
       @content;
     }
     @else {

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -1,6 +1,29 @@
 @mixin dark-mode($background: null, $colour: null) {
 
-  @media screen and (prefers-color-scheme: dark) {
+  @media screen and (prefers-color-scheme: dark), screen and (prefers-contrast: more) {
+
+    @if ($background != null and $colour != null) {
+      background-color: $background;
+      color: $colour;
+      @content;
+    }
+    @else if ($background != null and $colour == null) {
+      background-color: $background;
+      @content;
+    }
+    @else if ($colour != null and $background == null) {
+      color: $colour;
+      @content;
+    }
+    @else {
+      @content;
+    }
+  }
+}
+
+@mixin high-contrast($background: null, $colour: null) {
+
+  @media screen and (prefers-contrast: more) {
 
     @if ($background != null and $colour != null) {
       background-color: $background;
@@ -71,6 +94,7 @@
 @mixin highlight-box {
   background-color: $colour-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
+  @include high-contrast($background: $colour-high-contrast-highlight);
   border-radius: $border-radius-default;
   padding: 1em;
 
@@ -79,6 +103,7 @@
     &:focus {
       background-color: $colour-highlight;
       @include dark-mode($background: $colour-dark-mode-highlight);
+      @include high-contrast($background: $colour-high-contrast-highlight);
     }
   }
 }
@@ -107,6 +132,7 @@
   border-radius: $border-radius-default;
   background-color: $colour-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
+  @include high-contrast($background: $colour-high-contrast-highlight);
   display: block;
   box-shadow: 0 0 .25em lighten($colour-black, 85%);
   margin-bottom: 1em;

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -69,7 +69,7 @@
 }
 
 @mixin highlight-box {
-  background-color: $colour-primary-highlight;
+  background-color: $colour-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
   border-radius: $border-radius-default;
   padding: 1em;
@@ -77,7 +77,7 @@
   a {
 
     &:focus {
-      background-color: $colour-primary-highlight;
+      background-color: $colour-highlight;
       @include dark-mode($background: $colour-dark-mode-highlight);
     }
   }
@@ -105,7 +105,7 @@
 
 @mixin embedded-media {
   border-radius: $border-radius-default;
-  background-color: $colour-primary-highlight;
+  background-color: $colour-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
   display: block;
   box-shadow: 0 0 .25em lighten($colour-black, 85%);

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -108,7 +108,7 @@
   background-color: $colour-primary-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
   display: block;
-  box-shadow: 0 0 .25em lighten($black, 85%);
+  box-shadow: 0 0 .25em lighten($colour-black, 85%);
   margin-bottom: 1em;
   margin-top: 1em;
   height: auto;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -8,7 +8,7 @@ $xl: 85em;
 
 // Light mode colours
 $colour-primary: #0097db;
-$colour-primary-lighter: #008dd1;
+$colour-primary-lighter: #18abf2;
 $colour-primary-darker: #0073ab;
 $colour-black: #0b0c0c;
 $colour-white: #fff;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -12,7 +12,7 @@ $colour-primary-lighter: #008dd1;
 $colour-primary-darker: #0073ab;
 $colour-primary-highlight: #ebf8ff;
 $colour-black: #0b0c0c;
-$white: #fff;
+$colour-white: #fff;
 
 // Dark mode colours
 $colour-dark-mode-primary: #00a0f0;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -24,6 +24,10 @@ $colour-dark-mode-black: #1f1f22;
 $colour-dark-mode-highlight: #3d3d3d;
 $colour-dark-mode-main: #2c2c2c;
 
+// High contrast colours
+$colour-high-contrast-highlight: #171717;
+$colour-high-contrast-main: #000;
+
 // Code colours
 $colour-code-background: #f2f2f2;
 $colour-code-grey: #534f54;
@@ -39,6 +43,11 @@ $colour-dark-mode-code-magenta: #ff508c;
 $colour-dark-mode-code-purple: #9786e9;
 $colour-dark-mode-code-cyan: #00d7e9;
 $colour-dark-mode-code-yellow: #ffe648;
+
+// High contrast code colours
+$colour-high-contrast-code-background: $colour-high-contrast-highlight;
+$colour-high-contrast-code-magenta: #ff75a5;
+$colour-high-contrast-code-purple: #a498ec;
 
 // General styles
 $border-radius-default: 5px;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -10,18 +10,19 @@ $xl: 85em;
 $colour-primary: #0097db;
 $colour-primary-lighter: #008dd1;
 $colour-primary-darker: #0073ab;
-$colour-highlight: #ebf8ff;
 $colour-black: #0b0c0c;
 $colour-white: #fff;
+$colour-highlight: #ebf8ff;
+$colour-main: $colour-white;
 
 // Dark mode colours
 $colour-dark-mode-primary: #00a0f0;
 $colour-dark-mode-primary-lighter: #19b3ff;
 $colour-dark-mode-primary-darker: #008fd6;
-$colour-dark-mode-highlight: #3d3d3d;
-$colour-dark-mode-main: #2c2c2c;
 $colour-dark-mode-white: #f2f2f2;
 $colour-dark-mode-black: #1f1f22;
+$colour-dark-mode-highlight: #3d3d3d;
+$colour-dark-mode-main: #2c2c2c;
 
 // Code colours
 $colour-code-background: #f2f2f2;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -6,15 +6,13 @@ $m: 43em;
 $l: 60em;
 $xl: 85em;
 
-// Other colours
-$black: #0b0c0c;
-$white: #fff;
-
-// Primary colours
+// Light mode colours
 $colour-primary: #0097db;
 $colour-primary-lighter: #008dd1;
 $colour-primary-darker: #0073ab;
 $colour-primary-highlight: #ebf8ff;
+$colour-black: #0b0c0c;
+$white: #fff;
 
 // Dark mode colours
 $colour-dark-mode-primary: #00a0f0;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -10,7 +10,7 @@ $xl: 85em;
 $colour-primary: #0097db;
 $colour-primary-lighter: #008dd1;
 $colour-primary-darker: #0073ab;
-$colour-primary-highlight: #ebf8ff;
+$colour-highlight: #ebf8ff;
 $colour-black: #0b0c0c;
 $colour-white: #fff;
 

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -30,7 +30,7 @@
   &:visited {
     color: $white;
     text-decoration: none;
-    @include dark-mode($color: $colour-dark-mode-main);
+    @include dark-mode($colour: $colour-dark-mode-main);
   }
 
   &:hover {

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -13,9 +13,7 @@
   text-align: center;
   width: auto;
   text-decoration: none;
-  @include dark-mode() {
-    color: $colour-dark-mode-main;
-    background-color: $colour-dark-mode-primary;
+  @include dark-mode($colour-dark-mode-primary, $colour-dark-mode-main) {
     border-color: $colour-dark-mode-primary;
   }
 
@@ -51,7 +49,6 @@
   &:focus {
     outline: none;
     box-shadow: 0 0 0 3px $black;
-    border-radius: $border-radius-default;
     text-decoration: none;
     border-color: $colour-primary;
 

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -16,6 +16,9 @@
   @include dark-mode($colour-dark-mode-primary, $colour-dark-mode-main) {
     border-color: $colour-dark-mode-primary;
   }
+  @include high-contrast($colour-dark-mode-primary-lighter, $colour-high-contrast-main) {
+    border-color: $colour-dark-mode-primary-lighter;
+  }
 
   @media (max-width: $xs) {
     padding: .25em;
@@ -31,6 +34,7 @@
     color: $colour-white;
     text-decoration: none;
     @include dark-mode($colour: $colour-dark-mode-main);
+    @include high-contrast($colour: $colour-high-contrast-main);
   }
 
   &:hover {
@@ -38,6 +42,9 @@
     background-color: $colour-primary-darker;
     @include dark-mode($background: $colour-dark-mode-primary-lighter) {
       border-color: $colour-dark-mode-primary-lighter;
+    }
+    @include high-contrast($background: $colour-dark-mode-primary) {
+      border-color: $colour-dark-mode-primary;
     }
   }
 
@@ -51,10 +58,12 @@
     box-shadow: 0 0 0 3px $colour-black;
     text-decoration: none;
     border-color: $colour-primary;
-
     @include dark-mode() {
       box-shadow: 0 0 0 3px $colour-white;
       border-color: $colour-dark-mode-primary;
+    }
+    @include high-contrast() {
+      border-color: $colour-dark-mode-primary-lighter;
     }
   }
 
@@ -62,6 +71,9 @@
     border-color: $colour-primary-darker;
     @include dark-mode() {
       border-color: $colour-dark-mode-primary-lighter;
+    }
+    @include high-contrast() {
+      border-color: $colour-dark-mode-primary;
     }
   }
 

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -2,7 +2,7 @@
   background-color: $colour-primary;
   border: 3px solid $colour-primary;
   border-radius: $border-radius-default;
-  color: $white;
+  color: $colour-white;
   display: inline-block;
   display: inline-flex;
   align-items: center;
@@ -28,7 +28,7 @@
 
   &:link,
   &:visited {
-    color: $white;
+    color: $colour-white;
     text-decoration: none;
     @include dark-mode($colour: $colour-dark-mode-main);
   }
@@ -53,7 +53,7 @@
     border-color: $colour-primary;
 
     @include dark-mode() {
-      box-shadow: 0 0 0 3px $white;
+      box-shadow: 0 0 0 3px $colour-white;
       border-color: $colour-dark-mode-primary;
     }
   }

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -48,7 +48,7 @@
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px $black;
+    box-shadow: 0 0 0 3px $colour-black;
     text-decoration: none;
     border-color: $colour-primary;
 

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -22,7 +22,7 @@ input {
   }
 
   &:focus {
-    box-shadow: 0 0 0 3px $black;
+    box-shadow: 0 0 0 3px $colour-black;
 
     @include dark-mode() {
       box-shadow: 0 0 0 3px $white;

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -17,7 +17,7 @@ input {
   margin-bottom: 1em;
   padding: .5em .75em;
   width: 100%;
-  @include dark-mode($background: $colour-dark-mode-main, $color: $colour-dark-mode-white) {
+  @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white) {
     border-color: $colour-dark-mode-primary;
   }
 

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -21,6 +21,9 @@ input {
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white) {
     border-color: $colour-dark-mode-primary;
   }
+  @include high-contrast($background: $colour-high-contrast-main) {
+    border-color: $colour-dark-mode-primary-lighter;
+  }
 
   &:focus {
     box-shadow: 0 0 0 3px $colour-black;

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -10,6 +10,7 @@ label {
 }
 
 input {
+  background-color: $colour-main;
   border: 3px solid $colour-primary;
   border-radius: $border-radius-default;
   display: block;

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -6,7 +6,7 @@ form {
 
 label {
   font-family: $font--heading;
-  @include dark-mode($color: $colour-dark-mode-white);
+  @include dark-mode($colour: $colour-dark-mode-white);
 }
 
 input {

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -25,7 +25,7 @@ input {
     box-shadow: 0 0 0 3px $colour-black;
 
     @include dark-mode() {
-      box-shadow: 0 0 0 3px $white;
+      box-shadow: 0 0 0 3px $colour-white;
     }
   }
 }

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -66,7 +66,7 @@ fieldset {
 }
 
 legend {
-  color: $black;
+  color: $colour-black;
   padding: 0;
 }
 

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -12,7 +12,7 @@ kbd {
 pre code,
 pre {
   color: $black;
-  @include dark-mode ($color: $colour-dark-mode-white);
+  @include dark-mode ($colour: $colour-dark-mode-white);
 }
 
 pre {
@@ -48,7 +48,7 @@ pre {
   &.doctype,
   &.cdata {
     color: $colour-code-grey;
-    @include dark-mode($color: $colour-dark-mode-code-grey);
+    @include dark-mode($colour: $colour-dark-mode-code-grey);
   }
 
   &.punctuation {
@@ -62,13 +62,13 @@ pre {
   &.deleted,
   &.keyword {
     color: $colour-code-magenta;
-    @include dark-mode($color: $colour-dark-mode-code-magenta);
+    @include dark-mode($colour: $colour-dark-mode-code-magenta);
   }
 
   &.boolean,
   &.number {
     color: $colour-code-purple;
-    @include dark-mode($color: $colour-dark-mode-code-purple);
+    @include dark-mode($colour: $colour-dark-mode-code-purple);
   }
 
   &.selector,
@@ -84,7 +84,7 @@ pre {
   .style &.string,
   &.variable {
     color: $colour-code-cyan;
-    @include dark-mode($color: $colour-dark-mode-code-cyan);
+    @include dark-mode($colour: $colour-dark-mode-code-cyan);
   }
 
   &.atrule,
@@ -93,7 +93,7 @@ pre {
   &.regex,
   &.important {
     color: $colour-code-yellow;
-    @include dark-mode($color: $colour-dark-mode-code-yellow);
+    @include dark-mode($colour: $colour-dark-mode-code-yellow);
   }
 
   &.important,

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -6,20 +6,20 @@ kbd {
   font-size: .8em;
   border-radius: $border-radius-default/2;
   padding: .1em .1em .05em;
-  @include dark-mode ($colour-dark-mode-code-background, $colour-dark-mode-primary-darker);
+  @include dark-mode($colour-dark-mode-code-background, $colour-dark-mode-primary-darker);
   @include high-contrast($colour-high-contrast-code-background, $colour-dark-mode-primary-lighter);
 }
 
 pre code,
 pre {
   color: $colour-black;
-  @include dark-mode ($colour: $colour-dark-mode-white);
+  @include dark-mode($colour: $colour-dark-mode-white);
 }
 
 pre {
   background-color: $colour-code-background;
-  @include dark-mode ($background: $colour-dark-mode-code-background);
-  @include high-contrast ($background: $colour-high-contrast-code-background);
+  @include dark-mode($background: $colour-dark-mode-code-background);
+  @include high-contrast($background: $colour-high-contrast-code-background);
   padding: 1em;
   white-space: pre-wrap;
   word-spacing: normal;

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -7,6 +7,7 @@ kbd {
   border-radius: $border-radius-default/2;
   padding: .1em .1em .05em;
   @include dark-mode ($colour-dark-mode-code-background, $colour-dark-mode-primary-darker);
+  @include high-contrast($colour-high-contrast-code-background, $colour-dark-mode-primary-lighter);
 }
 
 pre code,
@@ -18,6 +19,7 @@ pre {
 pre {
   background-color: $colour-code-background;
   @include dark-mode ($background: $colour-dark-mode-code-background);
+  @include high-contrast ($background: $colour-high-contrast-code-background);
   padding: 1em;
   white-space: pre-wrap;
   word-spacing: normal;
@@ -63,12 +65,14 @@ pre {
   &.keyword {
     color: $colour-code-magenta;
     @include dark-mode($colour: $colour-dark-mode-code-magenta);
+    @include high-contrast($colour: $colour-high-contrast-code-magenta);
   }
 
   &.boolean,
   &.number {
     color: $colour-code-purple;
     @include dark-mode($colour: $colour-dark-mode-code-purple);
+    @include high-contrast($colour: $colour-high-contrast-code-purple);
   }
 
   &.selector,

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -48,10 +48,7 @@ pre {
   &.doctype,
   &.cdata {
     color: $colour-code-grey;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-grey;
-    }
+    @include dark-mode($color: $colour-dark-mode-code-grey);
   }
 
   &.punctuation {
@@ -65,19 +62,13 @@ pre {
   &.deleted,
   &.keyword {
     color: $colour-code-magenta;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-magenta;
-    }
+    @include dark-mode($color: $colour-dark-mode-code-magenta);
   }
 
   &.boolean,
   &.number {
     color: $colour-code-purple;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-purple;
-    }
+    @include dark-mode($color: $colour-dark-mode-code-purple);
   }
 
   &.selector,
@@ -93,10 +84,7 @@ pre {
   .style &.string,
   &.variable {
     color: $colour-code-cyan;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-cyan;
-    }
+    @include dark-mode($color: $colour-dark-mode-code-cyan);
   }
 
   &.atrule,
@@ -105,10 +93,7 @@ pre {
   &.regex,
   &.important {
     color: $colour-code-yellow;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-yellow;
-    }
+    @include dark-mode($color: $colour-dark-mode-code-yellow);
   }
 
   &.important,

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -11,7 +11,7 @@ kbd {
 
 pre code,
 pre {
-  color: $black;
+  color: $colour-black;
   @include dark-mode ($colour: $colour-dark-mode-white);
 }
 

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -1,12 +1,12 @@
 ::selection {
   background: $colour-primary;
-  @include dark-mode($colour: $black);
+  @include dark-mode($colour: $colour-black);
   color: $white;
 }
 
 html {
   @include font-body;
-  color: $black;
+  color: $colour-black;
   font-size: 120%;
 
   @media (max-width: $xxs) {

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -1,6 +1,6 @@
 ::selection {
   background: $colour-primary;
-  @include dark-mode($color: $black);
+  @include dark-mode($colour: $black);
   color: $white;
 }
 
@@ -96,7 +96,7 @@ li {
   &::marker {
     color: $colour-primary;
     font-family: $font--heading;
-    @include dark-mode($color: $colour-dark-mode-primary);
+    @include dark-mode($colour: $colour-dark-mode-primary);
   }
 }
 

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -28,7 +28,7 @@ html {
 }
 
 blockquote {
-  border-left: .15em solid $colour-primary-lighter;
+  border-left: .15em solid $colour-primary;
   font-style: italic;
   margin-left: 0;
   margin-right: 0;

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -108,10 +108,10 @@ li {
 hr {
   border-top: 2px solid $colour-primary;
   margin: 1em 0;
-  @include dark-mode () {
+  @include dark-mode() {
     border-color: $colour-primary;
   }
-  @include high-contrast () {
+  @include high-contrast() {
     border-color: $colour-dark-mode-primary-lighter;
   }
 }

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -1,6 +1,7 @@
 ::selection {
   background: $colour-primary;
   @include dark-mode($colour: $colour-black);
+  @include high-contrast($background: $colour-dark-mode-primary-lighter);
   color: $colour-white;
 }
 
@@ -40,6 +41,9 @@ blockquote {
 
   @include dark-mode() {
     border-left-color: $colour-dark-mode-primary;
+  }
+  @include high-contrast() {
+    border-left-color: $colour-dark-mode-primary-lighter;
   }
 
   ul,
@@ -97,6 +101,7 @@ li {
     color: $colour-primary;
     font-family: $font--heading;
     @include dark-mode($colour: $colour-dark-mode-primary);
+    @include high-contrast($colour: $colour-dark-mode-primary-lighter);
   }
 }
 
@@ -105,6 +110,9 @@ hr {
   margin: 1em 0;
   @include dark-mode () {
     border-color: $colour-primary;
+  }
+  @include high-contrast () {
+    border-color: $colour-dark-mode-primary-lighter;
   }
 }
 

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -1,7 +1,7 @@
 ::selection {
   background: $colour-primary;
   @include dark-mode($colour: $colour-black);
-  color: $white;
+  color: $colour-white;
 }
 
 html {

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -15,7 +15,7 @@
 
   &:focus {
     background-color: $white;
-    box-shadow: 0 0 0 1px $white,  0 0 0 4px $black;
+    box-shadow: 0 0 0 1px $white,  0 0 0 4px $colour-black;
     box-decoration-break: clone;
     @include dark-mode($background: $colour-dark-mode-main) {
       box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $white;

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -5,12 +5,14 @@
   &:visited {
     color: $colour-primary;
     @include dark-mode($colour: $colour-dark-mode-primary);
+    @include high-contrast($colour: $colour-dark-mode-primary-lighter);
   }
 
   &:hover,
   &:active {
     color: $colour-primary-darker;
     @include dark-mode($colour: $colour-dark-mode-primary-lighter);
+    @include high-contrast($colour: $colour-dark-mode-primary);
   }
 
   &:focus {
@@ -20,6 +22,9 @@
     @include dark-mode($background: $colour-dark-mode-main) {
       box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $colour-white;
     }
+    @include high-contrast($background: $colour-high-contrast-main) {
+      box-shadow: 0 0 0 1px $colour-high-contrast-main, 0 0 0 4px $colour-white;
+    }
   }
 }
 
@@ -27,8 +32,6 @@ a {
   @include text-link;
 
   > code {
-    // color: $colour-primary-darker;
-    // @include dark-mode($colour: $colour-dark-mode-primary);
     padding-left: 0;
     padding-right: 0;
   }

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -14,11 +14,11 @@
   }
 
   &:focus {
-    background-color: $white;
-    box-shadow: 0 0 0 1px $white,  0 0 0 4px $colour-black;
+    background-color: $colour-white;
+    box-shadow: 0 0 0 1px $colour-white,  0 0 0 4px $colour-black;
     box-decoration-break: clone;
     @include dark-mode($background: $colour-dark-mode-main) {
-      box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $white;
+      box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $colour-white;
     }
   }
 }

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -4,13 +4,13 @@
   &:link,
   &:visited {
     color: $colour-primary;
-    @include dark-mode($color: $colour-dark-mode-primary);
+    @include dark-mode($colour: $colour-dark-mode-primary);
   }
 
   &:hover,
   &:active {
     color: $colour-primary-darker;
-    @include dark-mode($color: $colour-dark-mode-primary-lighter);
+    @include dark-mode($colour: $colour-dark-mode-primary-lighter);
   }
 
   &:focus {
@@ -28,7 +28,7 @@ a {
 
   > code {
     // color: $colour-primary-darker;
-    // @include dark-mode($color: $colour-dark-mode-primary);
+    // @include dark-mode($colour: $colour-dark-mode-primary);
     padding-left: 0;
     padding-right: 0;
   }

--- a/src/scss/base/typography/_mixins.scss
+++ b/src/scss/base/typography/_mixins.scss
@@ -48,7 +48,7 @@ $font--heading: 'FS Me Web', sans-serif;
   font-weight: 400;
   line-height: 1.5;
 
-  @include dark-mode () {
+  @include dark-mode() {
     line-height: 1.7;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/src/scss/base/typography/_mixins.scss
+++ b/src/scss/base/typography/_mixins.scss
@@ -50,7 +50,8 @@ $font--heading: 'FS Me Web', sans-serif;
 
   @include dark-mode () {
     line-height: 1.7;
-    word-spacing: .05em;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -19,7 +19,8 @@
     height: 3px;
     margin-bottom: $section-spacing;
     width: 10em;
-    @include dark-mode ($background: $colour-primary);
+    @include dark-mode ($background: $colour-dark-mode-primary);
+    @include high-contrast ($background: $colour-dark-mode-primary-lighter);
 
     @media (max-width: $xxs) {
       margin-bottom: $section-spacing / 2;

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -13,7 +13,7 @@
   }
 
   &:before {
-    background-color: $black;
+    background-color: $colour-black;
     content: '';
     display: block;
     height: 3px;

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -19,8 +19,8 @@
     height: 3px;
     margin-bottom: $section-spacing;
     width: 10em;
-    @include dark-mode ($background: $colour-dark-mode-primary);
-    @include high-contrast ($background: $colour-dark-mode-primary-lighter);
+    @include dark-mode($background: $colour-dark-mode-primary);
+    @include high-contrast($background: $colour-dark-mode-primary-lighter);
 
     @media (max-width: $xxs) {
       margin-bottom: $section-spacing / 2;

--- a/src/scss/components/_logo.scss
+++ b/src/scss/components/_logo.scss
@@ -14,7 +14,7 @@
 
   .mark path,
   .trademark {
-    fill: $black;
+    fill: $colour-black;
     @include dark-mode() {
       fill: $colour-dark-mode-white;
     }

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -10,7 +10,7 @@ body {
 }
 
 .canvas {
-  @include dark-mode($background: $colour-dark-mode-main, $color: $colour-dark-mode-white);
+  @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
   background-color: $white;
   min-height: 100%;
   min-width: 100%;

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -12,6 +12,7 @@ body {
 
 .canvas {
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
+  @include high-contrast($background: $colour-high-contrast-main);
   background-color: $colour-main;
   min-height: 100%;
   min-width: 100%;

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -11,7 +11,7 @@ body {
 
 .canvas {
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
-  background-color: $white;
+  background-color: $colour-white;
   min-height: 100%;
   min-width: 100%;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -1,7 +1,8 @@
 html,
 body {
   overflow-x: hidden;
-  background-color: $colour-primary;
+  background-color: $colour-primary-lighter;
+  @include dark-mode($background: $colour-primary);
 }
 
 body {

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -11,7 +11,7 @@ body {
 
 .canvas {
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
-  background-color: $colour-white;
+  background-color: $colour-main;
   min-height: 100%;
   min-width: 100%;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);

--- a/src/scss/components/_skip-to-content.scss
+++ b/src/scss/components/_skip-to-content.scss
@@ -10,7 +10,7 @@
     height: auto;
     width: auto;
     margin: 0;
-    box-shadow: 0 0 0 3px $black, 0 0 .4em .0em $colour-dark-mode-black;
+    box-shadow: 0 0 0 3px $colour-black, 0 0 .4em .0em $colour-dark-mode-black;
     padding: 0.5em .5em;
 
     @include dark-mode() {

--- a/src/scss/components/_skip-to-content.scss
+++ b/src/scss/components/_skip-to-content.scss
@@ -14,7 +14,7 @@
     padding: 0.5em .5em;
 
     @include dark-mode() {
-      box-shadow: 0 0 0 3px $white, .2em .2em .4em .1em $colour-dark-mode-black;
+      box-shadow: 0 0 0 3px $colour-white, .2em .2em .4em .1em $colour-dark-mode-black;
     }
   }
 }


### PR DESCRIPTION
### Adds
 - Creates new main colour variable for consistency with Dark Mode colour palette
 - Adds anti-aliasing to dark mode text
 - Adds high contrast mode

 ### Changes
 - Uses `colour-` prefix for `$black` colour variable
 - Uses `colour-` prefix for `$white` colour variable
 - Renames `$colour-primary-highlight` to `$colour-highlight`

 ### Fixes
 - Corrects spelling of 'colour' in dark mode mixin
 - Makes scroll markers in light mode dark again
 - Removes letter spacing in dark mode to fix multi-word link underlines
 - Fixes spacing inconsistency with `@includes`

 ### Removes
 - Tidies up Dark Mode @includes
