### PR TITLE
Release version 5.16.0

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+----------
+
+
+## [5.16.0] - 2021-04-05
+
 ### Adds
 - Creates new main colour variable for consistency with Dark Mode colour palette
 - Adds anti-aliasing to dark mode text
@@ -29,8 +34,6 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Removes
 - Tidies up Dark Mode @includes
-
-----------
 
 
 ## [5.15.7] - 2021-04-04

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,25 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Adds
+- Creates new main colour variable for consistency with Dark Mode colour palette
+- Adds anti-aliasing to dark mode text
+- Adds high contrast mode
+
+### Changes
+- Uses `colour-` prefix for `$black` colour variable
+- Uses `colour-` prefix for `$white` colour variable
+- Renames `$colour-primary-highlight` to `$colour-highlight`
+
+### Fixes
+- Corrects spelling of 'colour' in dark mode mixin
+- Makes scroll markers in light mode dark again
+- Removes letter spacing in dark mode to fix multi-word link underlines
+- Fixes spacing inconsistency with `@includes`
+
+### Removes
+- Tidies up Dark Mode @includes
+
 ----------
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.15.7",
+  "version": "5.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.15.7",
+  "version": "5.16.0",
   "description": "tempertemper's website",
   "scripts": {
     "clear": "rm -rf dist",

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -1,18 +1,41 @@
-@mixin dark-mode($background: null, $color: null) {
+@mixin dark-mode($background: null, $colour: null) {
 
-  @media screen and (prefers-color-scheme: dark) {
+  @media screen and (prefers-color-scheme: dark), screen and (prefers-contrast: more) {
 
-    @if ($background != null and $color != null) {
+    @if ($background != null and $colour != null) {
       background-color: $background;
-      color: $color;
+      color: $colour;
       @content;
     }
-    @else if ($background != null and $color == null) {
+    @else if ($background != null and $colour == null) {
       background-color: $background;
       @content;
     }
-    @else if ($color != null and $background == null) {
-      color: $color;
+    @else if ($colour != null and $background == null) {
+      color: $colour;
+      @content;
+    }
+    @else {
+      @content;
+    }
+  }
+}
+
+@mixin high-contrast($background: null, $colour: null) {
+
+  @media screen and (prefers-contrast: more) {
+
+    @if ($background != null and $colour != null) {
+      background-color: $background;
+      color: $colour;
+      @content;
+    }
+    @else if ($background != null and $colour == null) {
+      background-color: $background;
+      @content;
+    }
+    @else if ($colour != null and $background == null) {
+      color: $colour;
       @content;
     }
     @else {
@@ -69,16 +92,18 @@
 }
 
 @mixin highlight-box {
-  background-color: $colour-primary-highlight;
+  background-color: $colour-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
+  @include high-contrast($background: $colour-high-contrast-highlight);
   border-radius: $border-radius-default;
   padding: 1em;
 
   a {
 
     &:focus {
-      background-color: $colour-primary-highlight;
+      background-color: $colour-highlight;
       @include dark-mode($background: $colour-dark-mode-highlight);
+      @include high-contrast($background: $colour-high-contrast-highlight);
     }
   }
 }
@@ -105,10 +130,11 @@
 
 @mixin embedded-media {
   border-radius: $border-radius-default;
-  background-color: $colour-primary-highlight;
+  background-color: $colour-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);
+  @include high-contrast($background: $colour-high-contrast-highlight);
   display: block;
-  box-shadow: 0 0 .25em lighten($black, 85%);
+  box-shadow: 0 0 .25em lighten($colour-black, 85%);
   margin-bottom: 1em;
   margin-top: 1em;
   height: auto;

--- a/src/scss/admin/_variables.scss
+++ b/src/scss/admin/_variables.scss
@@ -6,24 +6,27 @@ $m: 43em;
 $l: 60em;
 $xl: 85em;
 
-// Other colours
-$black: #0b0c0c;
-$white: #fff;
-
-// Primary colours
+// Light mode colours
 $colour-primary: #0097db;
-$colour-primary-lighter: #008dd1;
+$colour-primary-lighter: #18abf2;
 $colour-primary-darker: #0073ab;
-$colour-primary-highlight: #ebf8ff;
+$colour-black: #0b0c0c;
+$colour-white: #fff;
+$colour-highlight: #ebf8ff;
+$colour-main: $colour-white;
 
 // Dark mode colours
 $colour-dark-mode-primary: #00a0f0;
 $colour-dark-mode-primary-lighter: #19b3ff;
 $colour-dark-mode-primary-darker: #008fd6;
-$colour-dark-mode-highlight: #3d3d3d;
-$colour-dark-mode-main: #2c2c2c;
 $colour-dark-mode-white: #f2f2f2;
 $colour-dark-mode-black: #1f1f22;
+$colour-dark-mode-highlight: #3d3d3d;
+$colour-dark-mode-main: #2c2c2c;
+
+// High contrast colours
+$colour-high-contrast-highlight: #171717;
+$colour-high-contrast-main: #000;
 
 // Code colours
 $colour-code-background: #f2f2f2;
@@ -40,6 +43,11 @@ $colour-dark-mode-code-magenta: #ff508c;
 $colour-dark-mode-code-purple: #9786e9;
 $colour-dark-mode-code-cyan: #00d7e9;
 $colour-dark-mode-code-yellow: #ffe648;
+
+// High contrast code colours
+$colour-high-contrast-code-background: $colour-high-contrast-highlight;
+$colour-high-contrast-code-magenta: #ff75a5;
+$colour-high-contrast-code-purple: #a498ec;
 
 // General styles
 $border-radius-default: 5px;

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -2,7 +2,7 @@
   background-color: $colour-primary;
   border: 3px solid $colour-primary;
   border-radius: $border-radius-default;
-  color: $white;
+  color: $colour-white;
   display: inline-block;
   display: inline-flex;
   align-items: center;
@@ -13,10 +13,11 @@
   text-align: center;
   width: auto;
   text-decoration: none;
-  @include dark-mode() {
-    color: $colour-dark-mode-main;
-    background-color: $colour-dark-mode-primary;
+  @include dark-mode($colour-dark-mode-primary, $colour-dark-mode-main) {
     border-color: $colour-dark-mode-primary;
+  }
+  @include high-contrast($colour-dark-mode-primary-lighter, $colour-high-contrast-main) {
+    border-color: $colour-dark-mode-primary-lighter;
   }
 
   @media (max-width: $xs) {
@@ -30,9 +31,10 @@
 
   &:link,
   &:visited {
-    color: $white;
+    color: $colour-white;
     text-decoration: none;
-    @include dark-mode($color: $colour-dark-mode-main);
+    @include dark-mode($colour: $colour-dark-mode-main);
+    @include high-contrast($colour: $colour-high-contrast-main);
   }
 
   &:hover {
@@ -40,6 +42,9 @@
     background-color: $colour-primary-darker;
     @include dark-mode($background: $colour-dark-mode-primary-lighter) {
       border-color: $colour-dark-mode-primary-lighter;
+    }
+    @include high-contrast($background: $colour-dark-mode-primary) {
+      border-color: $colour-dark-mode-primary;
     }
   }
 
@@ -50,14 +55,15 @@
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px $black;
-    border-radius: $border-radius-default;
+    box-shadow: 0 0 0 3px $colour-black;
     text-decoration: none;
     border-color: $colour-primary;
-
     @include dark-mode() {
-      box-shadow: 0 0 0 3px $white;
+      box-shadow: 0 0 0 3px $colour-white;
       border-color: $colour-dark-mode-primary;
+    }
+    @include high-contrast() {
+      border-color: $colour-dark-mode-primary-lighter;
     }
   }
 
@@ -65,6 +71,9 @@
     border-color: $colour-primary-darker;
     @include dark-mode() {
       border-color: $colour-dark-mode-primary-lighter;
+    }
+    @include high-contrast() {
+      border-color: $colour-dark-mode-primary;
     }
   }
 

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -6,10 +6,11 @@ form {
 
 label {
   font-family: $font--heading;
-  @include dark-mode($color: $colour-dark-mode-white);
+  @include dark-mode($colour: $colour-dark-mode-white);
 }
 
 input {
+  background-color: $colour-main;
   border: 3px solid $colour-primary;
   border-radius: $border-radius-default;
   display: block;
@@ -17,15 +18,18 @@ input {
   margin-bottom: 1em;
   padding: .5em .75em;
   width: 100%;
-  @include dark-mode($background: $colour-dark-mode-main, $color: $colour-dark-mode-white) {
+  @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white) {
     border-color: $colour-dark-mode-primary;
+  }
+  @include high-contrast($background: $colour-high-contrast-main) {
+    border-color: $colour-dark-mode-primary-lighter;
   }
 
   &:focus {
-    box-shadow: 0 0 0 3px $black;
+    box-shadow: 0 0 0 3px $colour-black;
 
     @include dark-mode() {
-      box-shadow: 0 0 0 3px $white;
+      box-shadow: 0 0 0 3px $colour-white;
     }
   }
 }

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -66,7 +66,7 @@ fieldset {
 }
 
 legend {
-  color: $black;
+  color: $colour-black;
   padding: 0;
 }
 

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -6,18 +6,20 @@ kbd {
   font-size: .8em;
   border-radius: $border-radius-default/2;
   padding: .1em .1em .05em;
-  @include dark-mode ($colour-dark-mode-code-background, $colour-dark-mode-primary-darker);
+  @include dark-mode($colour-dark-mode-code-background, $colour-dark-mode-primary-darker);
+  @include high-contrast($colour-high-contrast-code-background, $colour-dark-mode-primary-lighter);
 }
 
 pre code,
 pre {
-  color: $black;
-  @include dark-mode ($color: $colour-dark-mode-white);
+  color: $colour-black;
+  @include dark-mode($colour: $colour-dark-mode-white);
 }
 
 pre {
   background-color: $colour-code-background;
-  @include dark-mode ($background: $colour-dark-mode-code-background);
+  @include dark-mode($background: $colour-dark-mode-code-background);
+  @include high-contrast($background: $colour-high-contrast-code-background);
   padding: 1em;
   white-space: pre-wrap;
   word-spacing: normal;
@@ -48,10 +50,7 @@ pre {
   &.doctype,
   &.cdata {
     color: $colour-code-grey;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-grey;
-    }
+    @include dark-mode($colour: $colour-dark-mode-code-grey);
   }
 
   &.punctuation {
@@ -65,19 +64,15 @@ pre {
   &.deleted,
   &.keyword {
     color: $colour-code-magenta;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-magenta;
-    }
+    @include dark-mode($colour: $colour-dark-mode-code-magenta);
+    @include high-contrast($colour: $colour-high-contrast-code-magenta);
   }
 
   &.boolean,
   &.number {
     color: $colour-code-purple;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-purple;
-    }
+    @include dark-mode($colour: $colour-dark-mode-code-purple);
+    @include high-contrast($colour: $colour-high-contrast-code-purple);
   }
 
   &.selector,
@@ -93,10 +88,7 @@ pre {
   .style &.string,
   &.variable {
     color: $colour-code-cyan;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-cyan;
-    }
+    @include dark-mode($colour: $colour-dark-mode-code-cyan);
   }
 
   &.atrule,
@@ -105,10 +97,7 @@ pre {
   &.regex,
   &.important {
     color: $colour-code-yellow;
-
-    @include dark-mode() {
-      color: $colour-dark-mode-code-yellow;
-    }
+    @include dark-mode($colour: $colour-dark-mode-code-yellow);
   }
 
   &.important,

--- a/src/scss/base/typography/_general.scss
+++ b/src/scss/base/typography/_general.scss
@@ -1,12 +1,13 @@
 ::selection {
   background: $colour-primary;
-  @include dark-mode($color: $black);
-  color: $white;
+  @include dark-mode($colour: $colour-black);
+  @include high-contrast($background: $colour-dark-mode-primary-lighter);
+  color: $colour-white;
 }
 
 html {
   @include font-body;
-  color: $black;
+  color: $colour-black;
   font-size: 120%;
 
   @media (max-width: $xxs) {
@@ -28,7 +29,7 @@ html {
 }
 
 blockquote {
-  border-left: .15em solid $colour-primary-lighter;
+  border-left: .15em solid $colour-primary;
   font-style: italic;
   margin-left: 0;
   margin-right: 0;
@@ -40,6 +41,9 @@ blockquote {
 
   @include dark-mode() {
     border-left-color: $colour-dark-mode-primary;
+  }
+  @include high-contrast() {
+    border-left-color: $colour-dark-mode-primary-lighter;
   }
 
   ul,
@@ -96,15 +100,19 @@ li {
   &::marker {
     color: $colour-primary;
     font-family: $font--heading;
-    @include dark-mode($color: $colour-dark-mode-primary);
+    @include dark-mode($colour: $colour-dark-mode-primary);
+    @include high-contrast($colour: $colour-dark-mode-primary-lighter);
   }
 }
 
 hr {
   border-top: 2px solid $colour-primary;
   margin: 1em 0;
-  @include dark-mode () {
+  @include dark-mode() {
     border-color: $colour-primary;
+  }
+  @include high-contrast() {
+    border-color: $colour-dark-mode-primary-lighter;
   }
 }
 

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -4,21 +4,26 @@
   &:link,
   &:visited {
     color: $colour-primary;
-    @include dark-mode($color: $colour-dark-mode-primary);
+    @include dark-mode($colour: $colour-dark-mode-primary);
+    @include high-contrast($colour: $colour-dark-mode-primary-lighter);
   }
 
   &:hover,
   &:active {
     color: $colour-primary-darker;
-    @include dark-mode($color: $colour-dark-mode-primary-lighter);
+    @include dark-mode($colour: $colour-dark-mode-primary-lighter);
+    @include high-contrast($colour: $colour-dark-mode-primary);
   }
 
   &:focus {
-    background-color: $white;
-    box-shadow: 0 0 0 1px $white,  0 0 0 4px $black;
+    background-color: $colour-white;
+    box-shadow: 0 0 0 1px $colour-white,  0 0 0 4px $colour-black;
     box-decoration-break: clone;
     @include dark-mode($background: $colour-dark-mode-main) {
-      box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $white;
+      box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $colour-white;
+    }
+    @include high-contrast($background: $colour-high-contrast-main) {
+      box-shadow: 0 0 0 1px $colour-high-contrast-main, 0 0 0 4px $colour-white;
     }
   }
 }
@@ -27,8 +32,6 @@ a {
   @include text-link;
 
   > code {
-    // color: $colour-primary-darker;
-    // @include dark-mode($color: $colour-dark-mode-primary);
     padding-left: 0;
     padding-right: 0;
   }

--- a/src/scss/base/typography/_mixins.scss
+++ b/src/scss/base/typography/_mixins.scss
@@ -48,9 +48,10 @@ $font--heading: 'FS Me Web', sans-serif;
   font-weight: 400;
   line-height: 1.5;
 
-  @include dark-mode () {
+  @include dark-mode() {
     line-height: 1.7;
-    word-spacing: .05em;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -13,13 +13,14 @@
   }
 
   &:before {
-    background-color: $black;
+    background-color: $colour-black;
     content: '';
     display: block;
     height: 3px;
     margin-bottom: $section-spacing;
     width: 10em;
-    @include dark-mode ($background: $colour-primary);
+    @include dark-mode($background: $colour-dark-mode-primary);
+    @include high-contrast($background: $colour-dark-mode-primary-lighter);
 
     @media (max-width: $xxs) {
       margin-bottom: $section-spacing / 2;

--- a/src/scss/components/_logo.scss
+++ b/src/scss/components/_logo.scss
@@ -14,7 +14,7 @@
 
   .mark path,
   .trademark {
-    fill: $black;
+    fill: $colour-black;
     @include dark-mode() {
       fill: $colour-dark-mode-white;
     }

--- a/src/scss/components/_page.scss
+++ b/src/scss/components/_page.scss
@@ -1,7 +1,8 @@
 html,
 body {
   overflow-x: hidden;
-  background-color: $colour-primary;
+  background-color: $colour-primary-lighter;
+  @include dark-mode($background: $colour-primary);
 }
 
 body {
@@ -10,8 +11,9 @@ body {
 }
 
 .canvas {
-  @include dark-mode($background: $colour-dark-mode-main, $color: $colour-dark-mode-white);
-  background-color: $white;
+  @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
+  @include high-contrast($background: $colour-high-contrast-main);
+  background-color: $colour-main;
   min-height: 100%;
   min-width: 100%;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);

--- a/src/scss/components/_skip-to-content.scss
+++ b/src/scss/components/_skip-to-content.scss
@@ -10,11 +10,11 @@
     height: auto;
     width: auto;
     margin: 0;
-    box-shadow: 0 0 0 3px $black, 0 0 .4em .0em $colour-dark-mode-black;
+    box-shadow: 0 0 0 3px $colour-black, 0 0 .4em .0em $colour-dark-mode-black;
     padding: 0.5em .5em;
 
     @include dark-mode() {
-      box-shadow: 0 0 0 3px $white, .2em .2em .4em .1em $colour-dark-mode-black;
+      box-shadow: 0 0 0 3px $colour-white, .2em .2em .4em .1em $colour-dark-mode-black;
     }
   }
 }

--- a/src/site/_data/site.json
+++ b/src/site/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "5.15.7",
+  "version": "5.16.0",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "https://github.com/tempertemper/tempertemper-website",


### PR DESCRIPTION
### Adds
- Creates new main colour variable for consistency with Dark Mode colour palette
- Adds anti-aliasing to dark mode text
- Adds high contrast mode

### Changes
- Uses `colour-` prefix for `$black` colour variable
- Uses `colour-` prefix for `$white` colour variable
- Renames `$colour-primary-highlight` to `$colour-highlight`

### Fixes
- Corrects spelling of 'colour' in dark mode mixin
- Makes scroll markers in light mode dark again
- Removes letter spacing in dark mode to fix multi-word link underlines
- Fixes spacing inconsistency with `@includes`

### Removes
- Tidies up Dark Mode @includes
