### PR TITLE
Adds focus-visible where appropriate, for tidier focus styles

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,15 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Adds
+- `:focus-visible` enhancement for links
+- `:focus-visible` enhancement for buttons
+- `:focus-visible` enhancement for tables
+
+### Removes
+- Removes button focus combination styles (focus + hover, focus + active)
+- Removes unnecessary text underline styling removal for link-button focus
+
 ----------
 
 

--- a/src/scss/admin/_mixins.scss
+++ b/src/scss/admin/_mixins.scss
@@ -105,6 +105,18 @@
       @include dark-mode($background: $colour-dark-mode-highlight);
       @include high-contrast($background: $colour-high-contrast-highlight);
     }
+
+    &:focus:not(:focus-visible) {
+      background-color: transparent;
+      @include dark-mode($background: transparent);
+      @include high-contrast($background: transparent);
+    }
+
+    &:focus-visible {
+      background-color: $colour-highlight;
+      @include dark-mode($background: $colour-dark-mode-highlight);
+      @include high-contrast($background: $colour-high-contrast-highlight);
+    }
   }
 }
 

--- a/src/scss/base/_buttons.scss
+++ b/src/scss/base/_buttons.scss
@@ -56,28 +56,35 @@
   &:focus {
     outline: none;
     box-shadow: 0 0 0 3px $colour-black;
-    text-decoration: none;
-    border-color: $colour-primary;
-    @include dark-mode() {
+    background-color: $colour-primary;
+    @include dark-mode($background: $colour-dark-mode-primary) {
       box-shadow: 0 0 0 3px $colour-white;
       border-color: $colour-dark-mode-primary;
     }
-    @include high-contrast() {
+    @include high-contrast($background: $colour-dark-mode-primary-lighter) {
       border-color: $colour-dark-mode-primary-lighter;
     }
   }
 
-  &:focus:hover {
-    border-color: $colour-primary-darker;
-    @include dark-mode() {
-      border-color: $colour-dark-mode-primary-lighter;
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+    background-color: $colour-primary;
+    @include dark-mode($background: $colour-dark-mode-primary) {
+      box-shadow: none;
     }
-    @include high-contrast() {
+    @include high-contrast($background: $colour-dark-mode-primary-lighter);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px $colour-black;
+    background-color: $colour-primary;
+    @include dark-mode($background: $colour-dark-mode-primary) {
+      box-shadow: 0 0 0 3px $colour-white;
       border-color: $colour-dark-mode-primary;
     }
-  }
-
-  &:focus:active {
-    box-shadow: none;
+    @include high-contrast($background: $colour-dark-mode-primary-lighter) {
+      border-color: $colour-dark-mode-primary-lighter;
+    }
   }
 }

--- a/src/scss/base/_tables.scss
+++ b/src/scss/base/_tables.scss
@@ -13,6 +13,26 @@
       box-shadow: 0 0 0 4px $colour-white;
     }
   }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+    @include dark-mode() {
+      box-shadow: none;
+    }
+    @include high-contrast() {
+      box-shadow: none;
+    }
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 4px $colour-black;
+    @include dark-mode() {
+      box-shadow: 0 0 0 4px $colour-white;
+    }
+    @include high-contrast() {
+      box-shadow: 0 0 0 4px $colour-white;
+    }
+  }
 }
 
 table {

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -26,6 +26,30 @@
       box-shadow: 0 0 0 1px $colour-high-contrast-main, 0 0 0 4px $colour-white;
     }
   }
+
+  &:focus:not(:focus-visible) {
+    background-color: transparent;
+    box-shadow: none;
+    box-decoration-break: slice;
+    @include dark-mode($background: $colour-dark-mode-main) {
+      box-shadow: none;
+    }
+    @include high-contrast($background: $colour-high-contrast-main) {
+      box-shadow: none;
+    }
+  }
+
+  &:focus-visible {
+    background-color: $colour-white;
+    box-shadow: 0 0 0 1px $colour-white, 0 0 0 4px $colour-black;
+    box-decoration-break: clone;
+    @include dark-mode($background: $colour-dark-mode-main) {
+      box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $colour-white;
+    }
+    @include high-contrast($background: $colour-high-contrast-main) {
+      box-shadow: 0 0 0 1px $colour-high-contrast-main, 0 0 0 4px $colour-white;
+    }
+  }
 }
 
 a {


### PR DESCRIPTION
### Adds
- `:focus-visible` enhancement for links
- `:focus-visible` enhancement for buttons
- `:focus-visible` enhancement for tables

### Removes
- Removes button focus combination styles (focus + hover, focus + active)
- Removes unnecessary text underline styling removal for link-button focus
