### PR TITLE
Release version 5.16.6

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixes
+- Uses `math.div()` syntax for division in Sass, ready for Dart Sass 2.0.0
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -11,10 +11,13 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+----------
+
+
+## [5.16.6] - 2021-06-04
+
 ### Fixes
 - Uses `math.div()` syntax for division in Sass, ready for Dart Sass 2.0.0
-
-----------
 
 
 ## [5.16.5] - 2021-06-03

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.16.5",
+  "version": "5.16.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "5.16.5",
+  "version": "5.16.6",
   "description": "tempertemper's website",
   "scripts": {
     "clear": "rm -rf dist",

--- a/src/scss/base/_tables.scss
+++ b/src/scss/base/_tables.scss
@@ -1,6 +1,8 @@
+@use "sass:math";
+
 .table-wrapper {
   overflow: auto;
-  border-radius: $border-radius-default/2;
+  border-radius: math.div($border-radius-default, 2);
   margin-top: 1em;
   margin-bottom: 1em;
 

--- a/src/scss/base/typography/_code.scss
+++ b/src/scss/base/typography/_code.scss
@@ -1,9 +1,11 @@
+@use "sass:math";
+
 code,
 kbd {
   background-color: $colour-code-background;
   font-family: $code--font;
   font-size: .8em;
-  border-radius: $border-radius-default/2;
+  border-radius: math.div($border-radius-default, 2);
   padding: .1em .1em .05em;
   @include dark-mode($colour-dark-mode-code-background);
   @include high-contrast($colour-high-contrast-code-background,);

--- a/src/scss/base/typography/_links.scss
+++ b/src/scss/base/typography/_links.scss
@@ -1,5 +1,7 @@
+@use "sass:math";
+
 @mixin text-link {
-  border-radius: $border-radius-default/2;
+  border-radius: math.div($border-radius-default, 2);
 
   &:link,
   &:visited:visited {

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .footer {
   clear: both;
   font-family: $font--heading;
@@ -5,7 +7,7 @@
   margin-top: $section-spacing * 2;
 
   @media (max-width: $xxs) {
-    margin-top: $section-spacing / 2;
+    margin-top: math.div($section-spacing, 2);
   }
 
   @media (min-width: $m) {
@@ -23,7 +25,7 @@
     @include high-contrast($background: $colour-dark-mode-primary-lighter);
 
     @media (max-width: $xxs) {
-      margin-bottom: $section-spacing / 2;
+      margin-bottom: math.div($section-spacing, 2);
     }
 
     @media (min-width: $m) {
@@ -38,7 +40,7 @@
   }
 
   .copyright {
-    margin-top: $section-spacing / 2;
+    margin-top: math.div($section-spacing, 2);
   }
 
   .utility {

--- a/src/site/_data/site.json
+++ b/src/site/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "5.16.5",
+  "version": "5.16.6",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "https://github.com/tempertemper/tempertemper-website",


### PR DESCRIPTION
### Fixes
- Uses `math.div()` syntax for division in Sass, ready for Dart Sass 2.0.0
