### PR TITLE
Release version 6.0.3

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Removes
+- Removes 'Read more' link from testimonials
+
+### Fixes
+- Uses `<ul>` rather than `<ol>` for featured blog posts
+- Moves post in list styling to critical CSS to stop layout shift
+- Adds index list marker removal to critical CSS to stop flash
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+----------
+
+
+## [6.0.3] - 2021-07-08
+
 ### Removes
 - Removes 'Read more' link from testimonials
 
@@ -18,8 +23,6 @@ All notable changes to this project will be documented in this file. The format 
 - Uses `<ul>` rather than `<ol>` for featured blog posts
 - Moves post in list styling to critical CSS to stop layout shift
 - Adds index list marker removal to critical CSS to stop flash
-
-----------
 
 
 ## [6.0.2] - 2021-07-05

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "tempertemper's website",
   "scripts": {
     "clear": "rm -rf dist",

--- a/src/scss/base/_utility--critical.scss
+++ b/src/scss/base/_utility--critical.scss
@@ -1,0 +1,3 @@
+.index-list {
+  @include remove-list-styling;
+}

--- a/src/scss/base/_utility--non-critical.scss
+++ b/src/scss/base/_utility--non-critical.scss
@@ -2,10 +2,6 @@
   @include visually-hidden;
 }
 
-.index-list {
-  @include remove-list-styling;
-}
-
 .button {
   @include button;
 }

--- a/src/scss/critical.scss
+++ b/src/scss/critical.scss
@@ -10,9 +10,11 @@
         'base/typography/general--critical',
         'base/typography/headings--critical',
         'base/links',
-        'base/images';
+        'base/images',
+        'base/utility--critical';
 
 @import 'components/header',
         'components/logo',
         'components/skip-to-content',
-        'components/navigation';
+        'components/navigation',
+        'components/post-in-list';

--- a/src/scss/non-critical.scss
+++ b/src/scss/non-critical.scss
@@ -13,10 +13,9 @@
         'base/buttons',
         'base/forms',
         'base/tables',
-        'base/utility';
+        'base/utility--non-critical';
 
 @import 'components/syntax-highlighting',
-        'components/post-in-list',
         'components/post-details',
         'components/teaser',
         'components/subscribe',

--- a/src/site/_data/site.json
+++ b/src/site/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "https://github.com/tempertemper/tempertemper-website",

--- a/src/site/_layouts/home.html
+++ b/src/site/_layouts/home.html
@@ -21,14 +21,14 @@ layout: base.html
 <section aria-labelledby="writing" class="teaser">
     <h2 id="writing">Writing</h2>
     <p>If you prefer to dive straight in rather than <a href="/blog/">see the full blog</a>, here are a couple of my favourite articles to get you started:</p>
-    <ol class="index-list" reversed>
+    <ul class="index-list" reversed>
         {%- set posts = collections.post | reverse %}
         {% for post in posts %}
             {% if post.data.featured === true %}
                 {% include "post-in-list.html" %}
             {% endif %}
         {% endfor %}
-    </ol>
+    </ul>
 </section>
 
 <section aria-labelledby="my-favourite-subjects">

--- a/src/site/testimonials.html
+++ b/src/site/testimonials.html
@@ -16,9 +16,6 @@ listing: true
             <blockquote>
                 &#8220;{{ testimonial.data.intro | markdown | safe  | striptags(true) }}&#8221;
             </blockquote>
-            <div class="read-more">
-                <a href="{{ testimonial.url | replace(".html", "") }}">View full testimonial<span class="visually-hidden"> from {{ testimonial.data.title }}</span></a>
-            </div>
         </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
### Removes
- Removes 'Read more' link from testimonials

### Fixes
- Uses `<ul>` rather than `<ol>` for featured blog posts
- Moves post in list styling to critical CSS to stop layout shift
- Adds index list marker removal to critical CSS to stop flash
