### PR TITLE
Removes scroll bounce background colour

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Removes
 - Removes unnecessary `.canvas` element, now that Safari doesn't show background colour on scroll bounce
 - Removes hidden horizontal scroll from page
+- Removes scroll bounce colour for Chrome and Firefox on macOS
 
 ----------
 

--- a/.changelog
+++ b/.changelog
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Removes
 - Removes unnecessary `.canvas` element, now that Safari doesn't show background colour on scroll bounce
+- Removes hidden horizontal scroll from page
 
 ----------
 

--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Removes
+- Removes unnecessary `.canvas` element, now that Safari doesn't show background colour on scroll bounce
+
 ----------
 
 

--- a/.changelog
+++ b/.changelog
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Removes
-- Removes unnecessary `.canvas` element, now that Safari doesn't show background colour on scroll bounce
+- Removes unnecessary `.canvas` and `.page-wrapper` elements, now that Safari doesn't show background colour on scroll bounce
 - Removes hidden horizontal scroll from page
 - Removes scroll bounce colour for Chrome and Firefox on macOS
 

--- a/.changelog
+++ b/.changelog
@@ -11,12 +11,15 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+----------
+
+
+## [6.0.22] - 2021-11-04
+
 ### Removes
 - Removes unnecessary `.canvas` and `.page-wrapper` elements, now that Safari doesn't show background colour on scroll bounce
 - Removes hidden horizontal scroll from page
 - Removes scroll bounce colour for Chrome and Firefox on macOS
-
-----------
 
 
 ## [6.0.21] - 2021-10-12

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.0.21",
+  "version": "6.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.0.21",
+  "version": "6.0.22",
   "description": "tempertemper's website",
   "scripts": {
     "clear": "rm -rf dist",

--- a/src/scss/base/_page.scss
+++ b/src/scss/base/_page.scss
@@ -1,8 +1,3 @@
-html {
-  background-color: $colour-primary-light;
-  @include dark-mode($background: $colour-primary);
-}
-
 body {
   background-color: $colour-main;
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);

--- a/src/scss/base/_page.scss
+++ b/src/scss/base/_page.scss
@@ -2,8 +2,6 @@ body {
   background-color: $colour-main;
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
   @include high-contrast($background: $colour-high-contrast-main);
-  min-height: 100%;
-  min-width: 100%;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 

--- a/src/scss/base/_page.scss
+++ b/src/scss/base/_page.scss
@@ -1,14 +1,13 @@
-html,
-body {
-  overflow-x: hidden;
+html {
   background-color: $colour-primary-light;
   @include dark-mode($background: $colour-primary);
 }
 
-.canvas {
+body {
+  overflow-x: hidden;
+  background-color: $colour-main;
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
   @include high-contrast($background: $colour-high-contrast-main);
-  background-color: $colour-main;
   min-height: 100%;
   min-width: 100%;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);

--- a/src/scss/base/_page.scss
+++ b/src/scss/base/_page.scss
@@ -3,8 +3,5 @@ body {
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
   @include high-contrast($background: $colour-high-contrast-main);
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
-}
-
-.page-wrapper {
   @include container;
 }

--- a/src/scss/base/_page.scss
+++ b/src/scss/base/_page.scss
@@ -4,7 +4,6 @@ html {
 }
 
 body {
-  overflow-x: hidden;
   background-color: $colour-main;
   @include dark-mode($colour-dark-mode-main, $colour-dark-mode-white);
   @include high-contrast($background: $colour-high-contrast-main);

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -1,7 +1,7 @@
 module.exports = {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "6.0.21",
+  "version": "6.0.22",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "https://github.com/tempertemper/tempertemper-website",

--- a/src/site/_layouts/base.html
+++ b/src/site/_layouts/base.html
@@ -2,17 +2,15 @@
 <html lang="en">
     {% include "head.html" %}
     <body>
-        <div class="page-wrapper">
-            <a href="#main" tabindex="0" class="skip-to-content">Skip to main content</a>
-            {% include "header.html" %}
-            <main id="main">
-                {{ content | safe }}
-                {% if cta %}
-                    {% include "call-to-action.html" %}
-                {% endif %}
-            </main>
-            {% include "footer.html" %}
-        </div>
+        <a href="#main" tabindex="0" class="skip-to-content">Skip to main content</a>
+        {% include "header.html" %}
+        <main id="main">
+            {{ content | safe }}
+            {% if cta %}
+                {% include "call-to-action.html" %}
+            {% endif %}
+        </main>
+        {% include "footer.html" %}
         <script>{% include "scripts.js" %}</script>
         <style>
           @media screen and (prefers-color-scheme: dark) {

--- a/src/site/_layouts/base.html
+++ b/src/site/_layouts/base.html
@@ -2,18 +2,16 @@
 <html lang="en">
     {% include "head.html" %}
     <body>
-        <div class="canvas">
-            <div class="page-wrapper">
-                <a href="#main" tabindex="0" class="skip-to-content">Skip to main content</a>
-                {% include "header.html" %}
-                <main id="main">
-                    {{ content | safe }}
-                    {% if cta %}
-                        {% include "call-to-action.html" %}
-                    {% endif %}
-                </main>
-                {% include "footer.html" %}
-            </div>
+        <div class="page-wrapper">
+            <a href="#main" tabindex="0" class="skip-to-content">Skip to main content</a>
+            {% include "header.html" %}
+            <main id="main">
+                {{ content | safe }}
+                {% if cta %}
+                    {% include "call-to-action.html" %}
+                {% endif %}
+            </main>
+            {% include "footer.html" %}
         </div>
         <script>{% include "scripts.js" %}</script>
         <style>


### PR DESCRIPTION
### Removes
- Removes unnecessary `.canvas` and `.page-wrapper` elements, now that Safari doesn't show background colour on scroll bounce
- Removes hidden horizontal scroll from page
- Removes scroll bounce colour for Chrome and Firefox on macOS
